### PR TITLE
fix: switch off in-manifest caption support

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -141,7 +141,7 @@ export const toM3u8 = dashPlaylists => {
     master.mediaGroups.AUDIO.audio = organizeAudioPlaylists(audioPlaylists);
   }
 
-  // turn off vtt playlist support until issues with VHS are resolved
+  // TODO: turn off vtt playlist support until issues with VHS are resolved
   if (vttPlaylists.length && false) {
     master.mediaGroups.SUBTITLES.subs = organizeVttPlaylists(vttPlaylists);
   }

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -141,7 +141,7 @@ export const toM3u8 = dashPlaylists => {
     master.mediaGroups.AUDIO.audio = organizeAudioPlaylists(audioPlaylists);
   }
 
-  // TODO: turn off vtt playlist support until issues with VHS are resolved
+  // TODO: vtt playlists not yet supported
   if (vttPlaylists.length && false) {
     master.mediaGroups.SUBTITLES.subs = organizeVttPlaylists(vttPlaylists);
   }

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -141,7 +141,8 @@ export const toM3u8 = dashPlaylists => {
     master.mediaGroups.AUDIO.audio = organizeAudioPlaylists(audioPlaylists);
   }
 
-  if (vttPlaylists.length) {
+  // turn off vtt playlist support until issues with VHS are resolved
+  if (vttPlaylists.length && false) {
     master.mediaGroups.SUBTITLES.subs = organizeVttPlaylists(vttPlaylists);
   }
 

--- a/test/manifests/maat_vtt_segmentTemplate.js
+++ b/test/manifests/maat_vtt_segmentTemplate.js
@@ -101,6 +101,9 @@ export const parsedManifest = {
       }
     },
     ['CLOSED-CAPTIONS']: {},
+    // Subtitles feature is turned off
+    SUBTITLES: {},
+    /*
     SUBTITLES: {
       subs: {
         en: {
@@ -141,6 +144,7 @@ export const parsedManifest = {
         }
       }
     },
+    */
     VIDEO: {}
   },
   playlists: [{

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -88,6 +88,9 @@ QUnit.test('playlists', function(assert) {
         }
       },
       ['CLOSED-CAPTIONS']: {},
+      // Subtitles feature is turned off
+      SUBTITLES: {},
+      /*
       SUBTITLES: {
         subs: {
           text: {
@@ -110,6 +113,7 @@ QUnit.test('playlists', function(assert) {
           }
         }
       },
+      */
       VIDEO: {}
     },
     playlists: [{


### PR DESCRIPTION
Right now selection a caption will produce an error, let's turn off this feature until the bugs are worked out.