### PR TITLE
add support for SegmentTemplate padding format string and SegmentTimeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: node_js
 node_js:
   - 8

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -14,16 +14,23 @@ export const rep = mpdAttributes => (period, periodIndex) => {
     const role = findChildren(adaptationSet, 'Role')[0];
     const roleAttributes = { role: getAttributes(role) };
 
-    const attrs = shallowMerge({ periodIndex }, mpdAttributes, adaptationSetAttributes, roleAttributes);
+    const attrs = shallowMerge({ periodIndex },
+                              mpdAttributes,
+                              adaptationSetAttributes,
+                              roleAttributes);
 
     const segmentTemplate = findChildren(adaptationSet, 'SegmentTemplate')[0];
+    const segmentTimeline =
+      segmentTemplate && findChildren(segmentTemplate, 'SegmentTimeline')[0];
     const segmentList = findChildren(adaptationSet, 'SegmentList')[0];
     const segmentBase = findChildren(adaptationSet, 'SegmentBase')[0];
 
-    const segmentType = {
-      segmentTemplate: segmentTemplate && getAttributes(segmentTemplate),
-      segmentList: segmentList && getAttributes(segmentList),
-      segmentBase: segmentBase && getAttributes(segmentBase)
+    const segmentInfo = {
+      template: segmentTemplate && getAttributes(segmentTemplate),
+      timeline: segmentTimeline &&
+                       findChildren(segmentTimeline, 'S').map(s => getAttributes(s)),
+      list: segmentList && getAttributes(segmentList),
+      base: segmentBase && getAttributes(segmentBase)
     };
 
     const representations = findChildren(adaptationSet, 'Representation');
@@ -32,9 +39,11 @@ export const rep = mpdAttributes => (period, periodIndex) => {
       // vtt tracks may use single file in BaseURL
       const baseUrlElement = findChildren(representation, 'BaseURL')[0];
       const baseUrl = baseUrlElement ? getContent(baseUrlElement) : '';
-      const attributes = shallowMerge(attrs, getAttributes(representation), { url: baseUrl });
+      const attributes = shallowMerge(attrs,
+                                      getAttributes(representation),
+                                      { url: baseUrl });
 
-      return { attributes, segmentType };
+      return { attributes, segmentInfo };
     };
 
     return representations.map(inherit);

--- a/src/segmentTemplate.js
+++ b/src/segmentTemplate.js
@@ -17,7 +17,10 @@ const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
  *        Value of the Representation@bandwidth attribute.
  * @param {number} values.Time
  *        Timestamp value of the corresponding segment
- * @return {(match: string, identifier: string, format: string, width: string) => string}
+ * @return {function(match: string,
+ *                   identifier: string,
+ *                   format: string,
+ *                   width: string): string}
  *         Callback to be used with String.prototype.replace to replace identifiers
  */
 export const identifierReplacement = (values) => (match, identifier, format, width) => {

--- a/src/segmentTemplate.js
+++ b/src/segmentTemplate.js
@@ -4,6 +4,25 @@ import resolveUrl from './resolveUrl';
 const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
 
 /**
+ * Replaces template identifiers with corresponding values. To be used as the callback
+ * for String.prototype.replace
+ *
+ * @name replaceCallback
+ * @function
+ * @param {string} match
+ *        Entire match of identifier
+ * @param {string} identifier
+ *        Name of matched identifier
+ * @param {string} format
+ *        Format tag string. Its presence indicates that padding is expected
+ * @param {string} width
+ *        Desired length of the replaced value. Values less than this width shall be left
+ *        zero padded
+ * @return {string}
+ *         Replacement for the matched identifier
+ */
+
+/**
  * Returns a function to be used as a callback for String.prototype.replace to replace
  * template identifiers
  *
@@ -17,10 +36,7 @@ const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
  *        Value of the Representation@bandwidth attribute.
  * @param {number} values.Time
  *        Timestamp value of the corresponding segment
- * @return {function(match: string,
- *                   identifier: string,
- *                   format: string,
- *                   width: string): string}
+ * @return {replaceCallback}
  *         Callback to be used with String.prototype.replace to replace identifiers
  */
 export const identifierReplacement = (values) => (match, identifier, format, width) => {

--- a/src/segmentTemplate.js
+++ b/src/segmentTemplate.js
@@ -1,0 +1,183 @@
+import { range } from './utils/list';
+import resolveUrl from './resolveUrl';
+
+const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
+
+export const identifierReplacement = (values) => (match, identifier, format, width) => {
+  if (match === '$$') {
+    // escape sequence
+    return '$';
+  }
+
+  if (typeof values[identifier] === 'undefined') {
+    return match;
+  }
+
+  const value = '' + values[identifier];
+
+  if (identifier === 'RepresentationID') {
+    // Format tag shall not be present with RepresentationID
+    return value;
+  }
+
+  if (!format) {
+    width = 1;
+  } else {
+    width = parseInt(width, 10);
+  }
+
+  if (value.length >= width) {
+    return value;
+  }
+
+  return `${(new Array(width - value.length + 1)).join('0')}${value}`;
+};
+
+export const constructTemplateUrl = (url, values) =>
+  url.replace(identifierPattern, identifierReplacement(values));
+
+export const parseByDuration = (start, timeline, timescale, duration, sourceDuration) => {
+  const count = Math.ceil(sourceDuration / (duration / timescale));
+
+  return range(start, start + count).map((number, index) => {
+    const segment = { number, duration: duration / timescale, timeline };
+
+    if (index === count - 1) {
+      // final segment may be less than duration
+      segment.duration = sourceDuration - (segment.duration * index);
+    }
+
+    segment.time = (segment.number - start) * duration;
+
+    return segment;
+  });
+};
+
+export const parseByTimeline =
+(start, timeline, timescale, segmentTimeline, sourceDuration) => {
+  const segments = [];
+  let time = -1;
+
+  for (let sIndex = 0; sIndex < segmentTimeline.length; sIndex++) {
+    const S = segmentTimeline[sIndex];
+    const duration = parseInt(S.d, 10);
+    const repeat = parseInt(S.r || 0, 10);
+    const segmentTime = parseInt(S.t || 0, 10);
+
+    if (time < 0) {
+      // first segment
+      time = segmentTime;
+    }
+
+    if (segmentTime && segmentTime > time) {
+      // discontinuity
+
+      // TODO: How to handle this type of discontinuity
+      // timeline++ here would treat it like HLS discontuity and content would
+      // get appended without gap
+      // E.G.
+      //  <S t="0" d="1" />
+      //  <S d="1" />
+      //  <S d="1" />
+      //  <S t="5" d="1" />
+      // would have $Time$ values of [0, 1, 2, 5]
+      // should this be appened at time positions [0, 1, 2, 3],(#EXT-X-DISCONTINUITY)
+      // or [0, 1, 2, gap, gap, 5]? (#EXT-X-GAP)
+      // does the value of sourceDuration consider this when calculating arbitrary
+      // negative @r repeat value?
+      // E.G. Same elements as above with this added at the end
+      //  <S d="1" r="-1" />
+      //  with a sourceDuration of 10
+      // Would the 2 gaps be included in the time duration calculations resulting in
+      // 8 segments with $Time$ values of [0, 1, 2, 5, 6, 7, 8, 9] or 10 segments
+      // with $Time$ values of [0, 1, 2, 5, 6, 7, 8, 9, 10, 11] ?
+
+      time = segmentTime;
+    }
+
+    let count;
+
+    if (repeat < 0) {
+      const nextS = sIndex + 1;
+
+      if (nextS === segmentTimeline.length) {
+        // last segment
+        // TODO: This may be incorrect depending on conclusion of TODO above
+        count = ((sourceDuration * timescale) - time) / duration;
+      } else {
+        count = (parseInt(segmentTimeline[nextS].t, 10) - time) / duration;
+      }
+    } else {
+      count = repeat + 1;
+    }
+
+    const end = start + segments.length + count;
+    let number = start + segments.length;
+
+    while (number < end) {
+      segments.push({ number, duration: duration / timescale, time, timeline });
+      time += duration;
+      number++;
+    }
+  }
+
+  return segments;
+};
+
+export const parseTemplateInfo = (attributes, segmentTimeline) => {
+  const start = parseInt(attributes.startNumber || 1, 10);
+  const timescale = parseInt(attributes.timescale || 1, 10);
+
+  if (!attributes.duration && !segmentTimeline) {
+    // if neither @duration or SegmentTimeline are present, then there shall be exactly
+    // one media segment
+    return [{
+      number: start,
+      duration: attributes.sourceDuration,
+      time: 0,
+      timeline: attributes.periodIndex
+    }];
+  }
+
+  if (attributes.duration) {
+    return parseByDuration(start,
+                           attributes.periodIndex,
+                           timescale,
+                           parseInt(attributes.duration, 10),
+                           attributes.sourceDuration);
+  }
+
+  return parseByTimeline(start,
+                         attributes.periodIndex,
+                         timescale,
+                         segmentTimeline,
+                         attributes.sourceDuration);
+
+};
+
+export const segmentsFromTemplate = (attributes, segmentTimeline) => {
+  const templateValues = {
+    RepresentationID: attributes.id,
+    Bandwidth: parseInt(attributes.bandwidth || 0, 10)
+  };
+  const mapUri = constructTemplateUrl(attributes.initialization || '', templateValues);
+  const segments = parseTemplateInfo(attributes, segmentTimeline);
+
+  return segments.map(segment => {
+    templateValues.Number = segment.number;
+    templateValues.Time = segment.time;
+
+    const uri = constructTemplateUrl(attributes.media || '', templateValues);
+
+    return {
+      uri,
+      timeline: segment.timeline,
+      duration: segment.duration,
+      resolvedUri: resolveUrl(attributes.baseUrl || '', uri),
+      map: {
+        uri: mapUri,
+        resolvedUri: resolveUrl(attributes.baseUrl || '', mapUri)
+      }
+    };
+  });
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,9 @@ import QUnit from 'qunit';
 
 // manifests
 import maatVttSegmentTemplate from './manifests/maat_vtt_segmentTemplate.mpd';
-import { parsedManifest as maatVttSegmentTemplateManifest } from './manifests/maat_vtt_segmentTemplate.js';
+import {
+  parsedManifest as maatVttSegmentTemplateManifest
+} from './manifests/maat_vtt_segmentTemplate.js';
 
 QUnit.module('mpd-parser');
 

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -6,7 +6,8 @@ import QUnit from 'qunit';
 QUnit.module('inheritAttributes');
 
 QUnit.test('needs at least one Period', function(assert) {
-  assert.throws(() => inheritAttributes(stringToMpdXml('<MPD></MPD>')), new RegExp(errors.INVALID_NUMBER_OF_PERIOD));
+  assert.throws(() => inheritAttributes(stringToMpdXml('<MPD></MPD>')),
+    new RegExp(errors.INVALID_NUMBER_OF_PERIOD));
 });
 
 QUnit.test('end to end', function(assert) {
@@ -18,7 +19,13 @@ QUnit.test('end to end', function(assert) {
       <AdaptationSet mimeType="video/mp4" >
           <Role value="main"></Role>
           <SegmentTemplate></SegmentTemplate>
-          <Representation bandwidth="5000000" codecs="avc1.64001e" height="404" id="test" width="720"></Representation>
+          <Representation
+            bandwidth="5000000"
+            codecs="avc1.64001e"
+            height="404"
+            id="test"
+            width="720">
+          </Representation>
         </AdaptationSet>
         <AdaptationSet mimeType="text/vtt" lang="en">
           <Representation bandwidth="256" id="en">
@@ -47,10 +54,11 @@ QUnit.test('end to end', function(assert) {
       url: '',
       width: '720'
     },
-    segmentType: {
-      segmentBase: undefined,
-      segmentList: undefined,
-      segmentTemplate: {}
+    segmentInfo: {
+      base: undefined,
+      list: undefined,
+      template: {},
+      timeline: undefined
     }
   }, {
     attributes: {
@@ -65,10 +73,11 @@ QUnit.test('end to end', function(assert) {
       sourceDuration: 30,
       url: 'https://example.com/en.vtt'
     },
-    segmentType: {
-      segmentBase: undefined,
-      segmentList: undefined,
-      segmentTemplate: undefined
+    segmentInfo: {
+      base: undefined,
+      list: undefined,
+      template: undefined,
+      timeline: undefined
     }
   }];
 

--- a/test/manifests/maat_vtt_segmentTemplate.js
+++ b/test/manifests/maat_vtt_segmentTemplate.js
@@ -46,6 +46,15 @@ export const parsedManifest = {
               resolvedUri: 'https://www.example.com/125000/2.m4f',
               timeline: 0,
               uri: '125000/2.m4f'
+            }, {
+              duration: 0.04800000000000004,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/init.m4f',
+                uri: '125000/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/3.m4f',
+              timeline: 0,
+              uri: '125000/3.m4f'
             }],
             timeline: 0,
             uri: ''
@@ -92,6 +101,15 @@ export const parsedManifest = {
               resolvedUri: 'https://www.example.com/125000/es/2.m4f',
               timeline: 0,
               uri: '125000/es/2.m4f'
+            }, {
+              duration: 0.04800000000000004,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
+                uri: '125000/es/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/es/3.m4f',
+              timeline: 0,
+              uri: '125000/es/3.m4f'
             }],
             timeline: 0,
             uri: ''
@@ -195,6 +213,15 @@ export const parsedManifest = {
       resolvedUri: 'https://www.example.com/482/2.m4f',
       timeline: 0,
       uri: '482/2.m4f'
+    }, {
+      duration: 0.24425000000000008,
+      map: {
+        resolvedUri: 'https://www.example.com/482/init.m4f',
+        uri: '482/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/482/3.m4f',
+      timeline: 0,
+      uri: '482/3.m4f'
     }],
     timeline: 0,
     uri: ''
@@ -240,6 +267,15 @@ export const parsedManifest = {
       resolvedUri: 'https://www.example.com/720/2.m4f',
       timeline: 0,
       uri: '720/2.m4f'
+    }, {
+      duration: 0.24425000000000008,
+      map: {
+        resolvedUri: 'https://www.example.com/720/init.m4f',
+        uri: '720/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/720/3.m4f',
+      timeline: 0,
+      uri: '720/3.m4f'
     }],
     timeline: 0,
     uri: ''

--- a/test/segmentTemplate.test.js
+++ b/test/segmentTemplate.test.js
@@ -1,0 +1,742 @@
+import QUnit from 'qunit';
+import {
+  constructTemplateUrl,
+  parseTemplateInfo,
+  segmentsFromTemplate
+} from '../src/segmentTemplate';
+
+QUnit.module('segmentTemplate - constructTemplateUrl');
+
+QUnit.test('does not change url with no identifiers', function(assert) {
+  const url = 'path/to/segment.mp4';
+
+  assert.equal(constructTemplateUrl(url, {}), url, 'no change');
+});
+
+QUnit.test('replaces each identifier individually', function(assert) {
+  const values = {
+    RepresentationID: 'Rep1',
+    Bandwidth: 1000,
+    Number: 2,
+    Time: 2000
+  };
+
+  const cases = [
+    {
+      url: '/$RepresentationID$/segment.mp4',
+      expected: '/Rep1/segment.mp4'
+    },
+    {
+      url: '/$Bandwidth$/segment.mp4',
+      expected: '/1000/segment.mp4'
+    },
+    {
+      url: '/$Number$/segment.mp4',
+      expected: '/2/segment.mp4'
+    },
+    {
+      url: '/$Time$/segment.mp4',
+      expected: '/2000/segment.mp4'
+    },
+    {
+      url: '/$$/segment.mp4',
+      expected: '/$/segment.mp4'
+    }
+  ];
+
+  cases.forEach(test => {
+    assert.equal(
+      constructTemplateUrl(test.url, values), test.expected, `constructs ${test.url}`);
+  });
+});
+
+QUnit.test('replaces multiple identifiers in url', function(assert) {
+  assert.equal(
+    constructTemplateUrl(
+      '$$$Time$$$$$/$RepresentationID$/$Bandwidth$/$Number$-$Time$-segment-$Number$.mp4',
+      {
+        RepresentationID: 'Rep1',
+        Bandwidth: 1000,
+        Number: 2,
+        Time: 2000
+      }),
+    '$2000$$/Rep1/1000/2-2000-segment-2.mp4',
+    'correctly replaces multiple identifiers in single url');
+});
+
+QUnit.test('does not replace unknown identifiers', function(assert) {
+  assert.equal(
+    constructTemplateUrl(
+      '/$UNKNOWN$/$RepresentationID$/$UNKOWN2$/$Number$.mp4',
+      {
+        RepresentationID: 'Rep1',
+        Number: 1
+      }),
+    '/$UNKNOWN$/Rep1/$UNKOWN2$/1.mp4',
+    'ignores unknown identifiers');
+});
+
+QUnit.test('honors padding format tag', function(assert) {
+  assert.equal(
+    constructTemplateUrl(
+      '/$Number%03d$/segment.mp4',
+      { Number: 7 }),
+    '/007/segment.mp4',
+    'correctly adds padding when format tag present');
+});
+
+QUnit.test('does not add padding when value is longer than width', function(assert) {
+  assert.equal(
+    constructTemplateUrl(
+      '/$Bandwidth%06d$/segment.mp4',
+      { Bandwidth: 999999999 }),
+    '/999999999/segment.mp4',
+    'no padding when value longer than format width');
+});
+
+QUnit.test('does not use padding format tag for $RepresentationID$', function(assert) {
+  assert.equal(
+    constructTemplateUrl(
+      '/$RepresentationID%09d$/$Number%03d$/segment.mp4',
+      { RepresentationID: 'Rep1', Number: 7 }),
+    '/Rep1/007/segment.mp4',
+    'ignores format tag for $RepresentationID$');
+});
+
+QUnit.module('segmentTemplate - parseTemplateInfo');
+
+QUnit.test('one media segment when no @duration attribute or SegmentTimeline element',
+function(assert) {
+  const attributes = {
+    startNumber: '3',
+    timescale: '1000',
+    sourceDuration: 42,
+    periodIndex: 1
+  };
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, void 0),
+    [ { number: 3, duration: 42, time: 0, timeline: 1 }],
+    'creates segment list of one media segment when no @duration attribute or timeline');
+});
+
+QUnit.test('uses @duration attribute when present', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    timescale: '1000',
+    sourceDuration: 16,
+    duration: '6000',
+    periodIndex: 1
+  };
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, []),
+    [
+      {
+        number: 0,
+        duration: 6,
+        timeline: 1,
+        time: 0
+      },
+      {
+        number: 1,
+        duration: 6,
+        timeline: 1,
+        time: 6000
+      },
+      {
+        number: 2,
+        duration: 4,
+        timeline: 1,
+        time: 12000
+      }
+    ],
+    'correctly parses segment durations and start times with @duration attribute');
+});
+
+QUnit.test('parseByDuration allows non zero startNumber', function(assert) {
+  const attributes = {
+    startNumber: '101',
+    timescale: '1000',
+    sourceDuration: 16,
+    duration: '6000',
+    periodIndex: 1
+  };
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, []),
+    [
+      {
+        number: 101,
+        duration: 6,
+        timeline: 1,
+        time: 0
+      },
+      {
+        number: 102,
+        duration: 6,
+        timeline: 1,
+        time: 6000
+      },
+      {
+        number: 103,
+        duration: 4,
+        timeline: 1,
+        time: 12000
+      }
+    ],
+    'allows non zero startNumber');
+});
+
+QUnit.test('parseByDuration defaults 1 for startNumber and timescale', function(assert) {
+  const attributes = {
+    sourceDuration: 11,
+    duration: '4',
+    periodIndex: 1
+  };
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, []),
+    [
+      {
+        number: 1,
+        duration: 4,
+        timeline: 1,
+        time: 0
+      },
+      {
+        number: 2,
+        duration: 4,
+        timeline: 1,
+        time: 4
+      },
+      {
+        number: 3,
+        duration: 3,
+        timeline: 1,
+        time: 8
+      }
+    ],
+    'uses default startNumber and timescale value of 1');
+});
+
+QUnit.test('uses SegmentTimeline info when no @duration attribute', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '6000'
+    },
+    {
+      d: '2000'
+    },
+    {
+      d: '3000'
+    },
+    {
+      d: '5000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 2,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 3,
+        time: 8000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 5,
+        time: 11000,
+        timeline: 1
+      }
+    ],
+    'correctly calculates segment durations and start times with SegmentTimeline');
+});
+
+QUnit.test('parseByTimeline allows non zero startNumber', function(assert) {
+  const attributes = {
+    startNumber: '101',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '6000'
+    },
+    {
+      d: '2000'
+    },
+    {
+      d: '3000'
+    },
+    {
+      d: '5000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 101,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 102,
+        duration: 2,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 103,
+        duration: 3,
+        time: 8000,
+        timeline: 1
+      },
+      {
+        number: 104,
+        duration: 5,
+        time: 11000,
+        timeline: 1
+      }
+    ],
+    'allows non zero startNumber');
+});
+
+QUnit.test('parseByTimeline defaults 1 for startNumber and timescale', function(assert) {
+  const attributes = {
+    sourceDuration: 11,
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '4'
+    },
+    {
+      d: '2'
+    },
+    {
+      d: '3'
+    },
+    {
+      d: '2'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 1,
+        duration: 4,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 2,
+        time: 4,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 3,
+        time: 6,
+        timeline: 1
+      },
+      {
+        number: 4,
+        duration: 2,
+        time: 9,
+        timeline: 1
+      }
+    ],
+    'defaults to 1 for startNumber and timescale');
+});
+
+QUnit.test('defaults SegmentTimeline.S@t to 0 for first segment', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      d: '6000'
+    },
+    {
+      d: '2000'
+    },
+    {
+      d: '3000'
+    },
+    {
+      d: '5000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 2,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 3,
+        time: 8000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 5,
+        time: 11000,
+        timeline: 1
+      }
+    ],
+    'uses default value of 0');
+});
+
+QUnit.test('allows non zero starting SegmentTimeline.S@t value', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '42000',
+      d: '6000'
+    },
+    {
+      d: '2000'
+    },
+    {
+      d: '3000'
+    },
+    {
+      d: '5000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 42000,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 2,
+        time: 48000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 3,
+        time: 50000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 5,
+        time: 53000,
+        timeline: 1
+      }
+    ],
+    'allows non zero SegmentTimeline.S@t start value');
+});
+
+QUnit.test('honors @r repeat attribute for SegmentTimeline.S', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '6000'
+    },
+    {
+      d: '1000',
+      r: '3'
+    },
+    {
+      d: '5000'
+    },
+    {
+      d: '1000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 1,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 1,
+        time: 7000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 1,
+        time: 8000,
+        timeline: 1
+      },
+      {
+        number: 4,
+        duration: 1,
+        time: 9000,
+        timeline: 1
+      },
+      {
+        number: 5,
+        duration: 5,
+        time: 10000,
+        timeline: 1
+      },
+      {
+        number: 6,
+        duration: 1,
+        time: 15000,
+        timeline: 1
+      }
+    ],
+    'correctly uses @r repeat attribute');
+});
+
+QUnit.test('correctly handles negative @r repeat value', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 16,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '6000'
+    },
+    {
+      d: '1000',
+      r: '-1'
+    },
+    {
+      t: '10000',
+      d: '5000'
+    },
+    {
+      d: '1000'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 1,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 1,
+        time: 7000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 1,
+        time: 8000,
+        timeline: 1
+      },
+      {
+        number: 4,
+        duration: 1,
+        time: 9000,
+        timeline: 1
+      },
+      {
+        number: 5,
+        duration: 5,
+        time: 10000,
+        timeline: 1
+      },
+      {
+        number: 6,
+        duration: 1,
+        time: 15000,
+        timeline: 1
+      }
+    ],
+    'correctly uses negative @r repeat attribute');
+});
+
+QUnit.test('correctly handles negative @r repeat value for last S', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    sourceDuration: 15,
+    timescale: '1000',
+    periodIndex: 1
+  };
+  const segmentTimeline = [
+    {
+      t: '0',
+      d: '6000'
+    },
+    {
+      d: '3000',
+      r: '-1'
+    }
+  ];
+
+  assert.deepEqual(
+    parseTemplateInfo(attributes, segmentTimeline),
+    [
+      {
+        number: 0,
+        duration: 6,
+        time: 0,
+        timeline: 1
+      },
+      {
+        number: 1,
+        duration: 3,
+        time: 6000,
+        timeline: 1
+      },
+      {
+        number: 2,
+        duration: 3,
+        time: 9000,
+        timeline: 1
+      },
+      {
+        number: 3,
+        duration: 3,
+        time: 12000,
+        timeline: 1
+      }
+    ],
+    'correctly uses negative @r repeat attribute for last S');
+});
+
+QUnit.skip('detects discontinuity when @t time is greater than expected start time',
+function(assert) {
+
+});
+
+QUnit.module('segmentTemplate - segmentsFromTemplate');
+
+QUnit.test('constructs simple segment list and resolves uris', function(assert) {
+  const attributes = {
+    startNumber: '0',
+    duration: '6000',
+    sourceDuration: 16,
+    timescale: '1000',
+    bandwidth: '100',
+    id: 'Rep1',
+    initialization: '$RepresentationID$/$Bandwidth$/init.mp4',
+    media: '$RepresentationID$/$Bandwidth$/$Number%03d$-$Time%05d$.mp4',
+    periodIndex: 1,
+    baseUrl: 'https://example.com/'
+  };
+  const segments = [
+    {
+      duration: 6,
+      map: {
+        resolvedUri: 'https://example.com/Rep1/100/init.mp4',
+        uri: 'Rep1/100/init.mp4'
+      },
+      resolvedUri: 'https://example.com/Rep1/100/000-00000.mp4',
+      timeline: 1,
+      uri: 'Rep1/100/000-00000.mp4'
+    },
+    {
+      duration: 6,
+      map: {
+        resolvedUri: 'https://example.com/Rep1/100/init.mp4',
+        uri: 'Rep1/100/init.mp4'
+      },
+      resolvedUri: 'https://example.com/Rep1/100/001-06000.mp4',
+      timeline: 1,
+      uri: 'Rep1/100/001-06000.mp4'
+    },
+    {
+      duration: 4,
+      map: {
+        resolvedUri: 'https://example.com/Rep1/100/init.mp4',
+        uri: 'Rep1/100/init.mp4'
+      },
+      resolvedUri: 'https://example.com/Rep1/100/002-12000.mp4',
+      timeline: 1,
+      uri: 'Rep1/100/002-12000.mp4'
+    }
+  ];
+
+  assert.deepEqual(segmentsFromTemplate(attributes, void 0), segments,
+    'creates segments from template');
+});
+

--- a/test/toPlaylists.test.js
+++ b/test/toPlaylists.test.js
@@ -1,6 +1,5 @@
 import {
-  toPlaylists,
-  segmentsFromTemplate
+  toPlaylists
 } from '../src/toPlaylists';
 import errors from '../src/errors';
 import QUnit from 'qunit';
@@ -11,62 +10,26 @@ QUnit.test('no representations', function(assert) {
   assert.deepEqual(toPlaylists([]), []);
 });
 
-QUnit.test('simple', function(assert) {
-  const attributes = {
-    startNumber: '0',
-    duration: '2000',
-    timescale: '1000',
-    id: 'id',
-    initialization: 'init.mp4',
-    sourceDuration: 6,
-    media: '$Number$.mp4',
-    periodIndex: '',
-    baseUrl: 'https://www.example.com/mpd/'
-  };
-
-  const segments = [{
-    duration: 2,
-    map: {
-      resolvedUri: 'https://www.example.com/mpd/init.mp4',
-      uri: 'init.mp4'
-    },
-    resolvedUri: 'https://www.example.com/mpd/0.mp4',
-    timeline: '',
-    uri: '0.mp4'
-  }, {
-    duration: 2,
-    map: {
-      resolvedUri: 'https://www.example.com/mpd/init.mp4',
-      uri: 'init.mp4'
-    },
-    resolvedUri: 'https://www.example.com/mpd/1.mp4',
-    timeline: '',
-    uri: '1.mp4'
-  }, {
-    duration: 2,
-    map: {
-      resolvedUri: 'https://www.example.com/mpd/init.mp4',
-      uri: 'init.mp4'
-    },
-    resolvedUri: 'https://www.example.com/mpd/2.mp4',
-    timeline: '',
-    uri: '2.mp4'
-  }];
-
-  assert.deepEqual(segmentsFromTemplate(attributes), segments);
-});
-
 QUnit.test('pretty simple', function(assert) {
   const representations = [{
-    attributes: {},
-    segmentType: {
-      segmentTemplate: true
+    attributes: { baseUrl: 'http://example.com/' },
+    segmentInfo: {
+      template: true
     }
   }];
 
   const playlists = [{
-    attributes: {},
-    segments: []
+    attributes: { baseUrl: 'http://example.com/' },
+    segments: [{
+      uri: '',
+      timeline: undefined,
+      duration: undefined,
+      resolvedUri: 'http://example.com/',
+      map: {
+        uri: '',
+        resolvedUri: 'http://example.com/'
+      }
+    }]
   }];
 
   assert.deepEqual(toPlaylists(representations), playlists);
@@ -75,8 +38,8 @@ QUnit.test('pretty simple', function(assert) {
 QUnit.test('segment base', function(assert) {
   const representations = [{
     attributes: {},
-    segmentType: {
-      segmentBase: true
+    segmentInfo: {
+      base: true
     }
   }];
 
@@ -87,8 +50,8 @@ QUnit.test('segment base', function(assert) {
 QUnit.test('segment list', function(assert) {
   const representations = [{
     attributes: {},
-    segmentType: {
-      segmentList: true
+    segmentInfo: {
+      list: true
     }
   }];
 


### PR DESCRIPTION
This adds support for the following SegmentTemplate features
* template string identifier replacement with padding format tag support
  * $$
  * $RepresentationID$
  * $Number%0{x}d$
  * $Bandwidth%0{x}d$
  * $Time%0{x}d$
* build segments from **SegmentTimeline** element
  