### PR TITLE
fix: babel es module

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -76,7 +76,10 @@ export default [
     legacy: true,
     banner,
     external: ['global/window', 'url-toolkit'],
-    plugins: [ json({ preferConst: true }) ],
+    plugins: [
+      json({ preferConst: true }),
+      babel({ exclude: 'node_modules/**' })
+    ],
     output: [
       {file: 'dist/mpd-parser.es.js', format: 'es'}
     ]


### PR DESCRIPTION
The purpose of this change is to babel the ES6 module export for compatibility. The project may be using features that are not common or considered experimental.