### PR TITLE
feat: add sidx information to segment base playlists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mpd-parser",
-  "version": "0.7.0",
+  "version": "0.8.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpd-parser",
-  "version": "0.7.0",
+  "version": "0.8.0-0",
   "description": "mpd parser",
   "main": "dist/mpd-parser.cjs.js",
   "module": "dist/mpd-parser.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { version } from '../package.json';
-import { toM3u8 } from './toM3u8';
+import { toM3u8, addSegmentInfo } from './toM3u8';
 import { toPlaylists } from './toPlaylists';
 import { inheritAttributes } from './inheritAttributes';
 import { stringToMpdXml } from './stringToMpdXml';
@@ -20,3 +20,10 @@ export const parse = (manifestString, options) =>
  */
 export const parseUTCTiming = (manifestString) =>
   parseUTCTimingScheme(stringToMpdXml(manifestString));
+
+export const attachSegmentInfoFromSidx = (playlist, sidx) => {
+  return addSegmentInfo({
+    dashPlaylist: playlist,
+    sidx
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { parseUTCTimingScheme } from './parseUTCTimingScheme';
 
 export const VERSION = version;
 
-export const parse = (manifestString, options) =>
+export const parse = (manifestString, options = {}) =>
   toM3u8(toPlaylists(inheritAttributes(stringToMpdXml(manifestString), options)), options.sidxMapping);
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { version } from '../package.json';
-import { toM3u8, addSegmentInfo } from './toM3u8';
+import { toM3u8 } from './toM3u8';
 import { toPlaylists } from './toPlaylists';
 import { inheritAttributes } from './inheritAttributes';
 import { stringToMpdXml } from './stringToMpdXml';
@@ -8,7 +8,7 @@ import { parseUTCTimingScheme } from './parseUTCTimingScheme';
 export const VERSION = version;
 
 export const parse = (manifestString, options) =>
-  toM3u8(toPlaylists(inheritAttributes(stringToMpdXml(manifestString), options)));
+  toM3u8(toPlaylists(inheritAttributes(stringToMpdXml(manifestString), options)), options.sidxMapping);
 
 /**
  * Parses the manifest for a UTCTiming node, returning the nodes attributes if found
@@ -20,10 +20,3 @@ export const parse = (manifestString, options) =>
  */
 export const parseUTCTiming = (manifestString) =>
   parseUTCTimingScheme(stringToMpdXml(manifestString));
-
-export const attachSegmentInfoFromSidx = ({ master, sidxMapping}) => {
-  return addSegmentInfo({
-    master,
-    sidxMapping
-  });
-};

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,9 @@ export const parse = (manifestString, options) =>
 export const parseUTCTiming = (manifestString) =>
   parseUTCTimingScheme(stringToMpdXml(manifestString));
 
-export const attachSegmentInfoFromSidx = (playlist, sidx) => {
+export const attachSegmentInfoFromSidx = ({ master, sidxMapping}) => {
   return addSegmentInfo({
-    dashPlaylist: playlist,
-    sidx
+    master,
+    sidxMapping
   });
 };

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -32,6 +32,12 @@ export const segmentsFromBase = (attributes) => {
     source: initialization.sourceURL,
     range: initialization.range
   });
+
+  if (indexRange) {
+    // sidx is defined so do not try to parse segments
+    return [];
+  }
+
   const segment = urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
 
   segment.map = initSegment;
@@ -54,4 +60,17 @@ export const segmentsFromBase = (attributes) => {
   segment.number = 0;
 
   return [segment];
+};
+
+export const sidxFromBase = (attributes) => {
+  const {
+    baseUrl,
+    indexRange = ''
+  } = attributes;
+
+  if (!indexRange) {
+    return null;
+  }
+
+  return urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
 };

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -33,10 +33,12 @@ export const segmentsFromBase = (attributes) => {
     range: initialization.range
   });
 
-  if (indexRange) {
-    // sidx is defined so do not try to parse segments
-    return [];
-  }
+  // TODO: if we return here we will lose some attributes and init segment
+
+  // if (indexRange) {
+  //   // sidx is defined so do not try to parse segments
+  //   return [];
+  // }
 
   const segment = urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
 

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -57,6 +57,17 @@ export const segmentsFromBase = (attributes) => {
   return [segment];
 };
 
+/**
+ * Given a playlist, a sidx box, and a baseUrl, update the segment list of the playlist
+ * according to the sidx information given.
+ *
+ * playlist.sidx has metadadata about the sidx where-as the sidx param
+ * is the parsed sidx box itself.
+ *
+ * @param {Object} playlist the playlist to update the sidx information for
+ * @param {Object} sidx the parsed sidx box
+ * @return {Object} the playlist object with the updated sidx information
+ */
 export const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
   // Retain init segment information
   const initSegment = playlist.sidx.map ? playlist.sidx.map : null;

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -33,7 +33,7 @@ export const segmentsFromBase = (attributes, timeline) => {
     range: initialization.range
   });
 
-  const segment = urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
+  const segment = urlTypeConverter({ baseUrl, source: baseUrl, indexRange });
 
   segment.map = initSegment;
 
@@ -60,12 +60,30 @@ export const segmentsFromBase = (attributes, timeline) => {
 export const sidxFromBase = (attributes) => {
   const {
     baseUrl,
-    indexRange = ''
+    indexRange = '',
+    initialization
   } = attributes;
 
   if (!indexRange) {
     return null;
   }
 
-  return urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
+  const sidxSegment = urlTypeConverter({
+    baseUrl,
+    source: baseUrl,
+    indexRange
+  });
+
+  let initSegment;
+
+  if (initialization) {
+    initSegment = urlTypeConverter({
+      baseUrl,
+      source: initialization.sourceURL,
+      range: initialization.range
+    });
+  }
+
+  sidxSegment.map = initSegment;
+  return sidxSegment;
 };

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -12,7 +12,7 @@ import { parseByDuration } from './durationTimeParser';
  *   names as keys
  * @return {Object.<Array>} list of segments
  */
-export const segmentsFromBase = (attributes) => {
+export const segmentsFromBase = (attributes, timeline) => {
   const {
     baseUrl,
     initialization = {},
@@ -32,13 +32,6 @@ export const segmentsFromBase = (attributes) => {
     source: initialization.sourceURL,
     range: initialization.range
   });
-
-  // TODO: if we return here we will lose some attributes and init segment
-
-  // if (indexRange) {
-  //   // sidx is defined so do not try to parse segments
-  //   return [];
-  // }
 
   const segment = urlTypeConverter({ baseUrl, source: baseUrl, range: indexRange });
 

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -12,7 +12,7 @@ import { parseByDuration } from './durationTimeParser';
  *   names as keys
  * @return {Object.<Array>} list of segments
  */
-export const segmentsFromBase = (attributes, timeline) => {
+export const segmentsFromBase = (attributes) => {
   const {
     baseUrl,
     initialization = {},

--- a/src/segment/urlType.js
+++ b/src/segment/urlType.js
@@ -49,6 +49,8 @@ export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '', indexR
 };
 
 export const byteRangeToString = (byterange) => {
+  // `endRange` is one less than `offset + length` because the HTTP range
+  // header uses inclusive ranges
   const endRange = byterange.offset + byterange.length - 1;
 
   return `${byterange.offset}-${endRange}`;

--- a/src/segment/urlType.js
+++ b/src/segment/urlType.js
@@ -48,4 +48,10 @@ export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '', indexR
   return segment;
 };
 
+export const byteRangeToString = (byterange) => {
+  const endRange = byterange.offset + byterange.length - 1;
+
+  return `${byterange.offset}-${endRange}`;
+};
+
 export default urlTypeToSegment;

--- a/src/segment/urlType.js
+++ b/src/segment/urlType.js
@@ -25,26 +25,27 @@ import resolveUrl from '../utils/resolveUrl';
  * @return {SingleUri} full segment information transformed into a format similar
  *   to m3u8-parser
  */
-export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '' }) => {
-  const init = {
+export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '', indexRange = '' }) => {
+  const segment = {
     uri: source,
     resolvedUri: resolveUrl(baseUrl || '', source)
   };
 
-  if (range) {
-    const ranges = range.split('-');
+  if (range || indexRange) {
+    const rangeStr = range ? range : indexRange;
+    const ranges = rangeStr.split('-');
     const startRange = parseInt(ranges[0], 10);
     const endRange = parseInt(ranges[1], 10);
 
     // byterange should be inclusive according to
     // RFC 2616, Clause 14.35.1
-    init.byterange = {
+    segment.byterange = {
       length: endRange - startRange + 1,
       offset: startRange
     };
   }
 
-  return init;
+  return segment;
 };
 
 export default urlTypeToSegment;

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -141,7 +141,7 @@ export const organizeVttPlaylists = playlists => {
   }, {});
 };
 
-export const formatVideoPlaylist = ({ attributes, segments }) => {
+export const formatVideoPlaylist = ({ attributes, segments, sidx }) => {
   const playlist = {
     attributes: {
       NAME: attributes.id,
@@ -166,6 +166,10 @@ export const formatVideoPlaylist = ({ attributes, segments }) => {
 
   if (attributes.contentProtection) {
     playlist.contentProtection = attributes.contentProtection;
+  }
+
+  if (sidx) {
+    playlist.sidx = sidx;
   }
 
   return playlist;

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -180,9 +180,6 @@ export const addSegmentInfo = ({ dashPlaylist, sidx }) => {
   const mediaReferences = sidx.references.filter(r => r.referenceType !== 1);
   const segments = [];
 
-  // debugger;
-
-  // const attributeDuration = dashPlaylist.segments[0].duration;
   // const originalTimeline = dashPlaylist.segments[0].timeline;
   const sidxEnd = dashPlaylist.sidx.byterange.offset +
     dashPlaylist.sidx.byterange.length;
@@ -190,27 +187,29 @@ export const addSegmentInfo = ({ dashPlaylist, sidx }) => {
   let startIndex = sidxEnd;
 
   for (let i = 0; i < mediaReferences.length; i++) {
-    const size = sidx.references[i].referencedSize;
+    const reference = sidx.references[i];
+    const size = reference.referencedSize;
 
     // TODO double check these
     const segment = segmentsFromBase({
       baseUrl: dashPlaylist.resolvedUri,
       initialization: {},
       timescale: sidx.timescale
-      // duration: attributeDuration
     })[0];
 
     segment.byterange = {
       length: size,
       offset: startIndex
     };
-
+    // TODO check how to do this properly
+    segment.duration = reference.subsegmentDuration;
     segments.push(segment);
-
     startIndex += size;
   }
 
   dashPlaylist.segments = segments;
+  // this isn't needed anymore
+  delete dashPlaylist.sidx;
 
   return dashPlaylist;
 };

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -176,7 +176,7 @@ export const formatVideoPlaylist = ({ attributes, segments, sidx }) => {
   return playlist;
 };
 
-const addSegmentsToPlaylist = (playlist, sidx) => {
+const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
   const mediaReferences = sidx.references.filter(r => r.referenceType !== 1);
   const segments = [];
 
@@ -192,7 +192,7 @@ const addSegmentsToPlaylist = (playlist, sidx) => {
 
     // TODO double check these
     const segment = segmentsFromBase({
-      baseUrl: playlist.resolvedUri,
+      baseUrl,
       initialization: {},
       timescale: sidx.timescale
     })[0];
@@ -216,11 +216,11 @@ const addSegmentsToPlaylist = (playlist, sidx) => {
 
 export const addSegmentInfo = ({ master, sidxMapping}) => {
   for (let i = 0; i < master.playlists.length; i++) {
-    const playlist = master.playlists[0];
+    const playlist = master.playlists[i];
     const sidxMatch = sidxMapping[playlist.uri] || sidxMapping[playlist.resolvedUri];
 
     if (sidxMatch) {
-      addSegmentsToPlaylist(playlist, sidxMatch.sidx);
+      addSegmentsToPlaylist(playlist, sidxMatch.sidx, playlist.sidx.resolvedUri);
     }
   }
 

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -40,7 +40,7 @@ const mergeDiscontiguousPlaylists = playlists => {
   });
 };
 
-const addSegmentInfoFromSidx = (playlists, sidxMapping) => {
+const addSegmentInfoFromSidx = (playlists, sidxMapping = {}) => {
   if (!Object.keys(sidxMapping).length) {
     return playlists;
   }
@@ -116,7 +116,7 @@ export const formatVttPlaylist = ({ attributes, segments }) => {
   };
 };
 
-export const organizeAudioPlaylists = (playlists, sidxMapping) => {
+export const organizeAudioPlaylists = (playlists, sidxMapping = {}) => {
   let mainPlaylist;
 
   const formattedPlaylists = playlists.reduce((a, playlist) => {
@@ -168,7 +168,7 @@ export const organizeAudioPlaylists = (playlists, sidxMapping) => {
   return formattedPlaylists;
 };
 
-export const organizeVttPlaylists = (playlists, sidxMapping) => {
+export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
     const label = playlist.attributes.lang || 'text';
 

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -37,7 +37,7 @@ const mergeDiscontiguousPlaylists = playlists => {
   });
 };
 
-export const formatAudioPlaylist = ({ attributes, segments }) => {
+export const formatAudioPlaylist = ({ attributes, segments, sidx }) => {
   const playlist = {
     attributes: {
       NAME: attributes.id,
@@ -56,6 +56,10 @@ export const formatAudioPlaylist = ({ attributes, segments }) => {
 
   if (attributes.contentProtection) {
     playlist.contentProtection = attributes.contentProtection;
+  }
+
+  if (sidx) {
+    playlist.sidx = sidx;
   }
 
   return playlist;
@@ -215,11 +219,11 @@ const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
 };
 
 export const addSegmentInfo = ({ master, sidxMapping}) => {
-  for (let i = 0; i < master.playlists.length; i++) {
+  for (const i in master.playlists) {
     const playlist = master.playlists[i];
     const sidxMatch = sidxMapping[playlist.uri] || sidxMapping[playlist.resolvedUri];
 
-    if (sidxMatch) {
+    if (sidxMatch && playlist.sidx) {
       addSegmentsToPlaylist(playlist, sidxMatch.sidx, playlist.sidx.resolvedUri);
     }
   }

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -47,10 +47,10 @@ const addSegmentInfoFromSidx = (playlists, sidxMapping) => {
     const playlist = playlists[i];
     const sidxKey = playlist.sidx.uri + '-' +
       byteRangeToString(playlist.sidx.byterange);
-    const sidxMatch = sidxMapping[sidxKey];
+    const sidxMatch = sidxMapping[sidxKey] && sidxMapping[sidxKey].sidx;
 
     if (playlist.sidx && sidxMatch) {
-      addSegmentsToPlaylist(playlist, sidxMatch.sidx, playlist.sidx.resolvedUri);
+      addSegmentsToPlaylist(playlist, sidxMatch, playlist.sidx.resolvedUri);
     }
   }
 

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -95,15 +95,19 @@ export const formatVttPlaylist = ({ attributes, segments }) => {
 };
 
 export const organizeAudioPlaylists = playlists => {
-  return playlists.reduce((a, playlist) => {
+  let mainPlaylist;
+
+  const formattedPlaylists = playlists.reduce((a, playlist) => {
     const role = playlist.attributes.role &&
-      playlist.attributes.role.value || 'main';
+      playlist.attributes.role.value || '';
     const language = playlist.attributes.lang || '';
 
     let label = 'main';
 
     if (language) {
-      label = `${playlist.attributes.lang} (${role})`;
+      const roleLabel = role ? ` (${role})` : '';
+
+      label = `${playlist.attributes.lang}${roleLabel}`;
     }
 
     // skip if we already have the highest quality audio for a language
@@ -121,8 +125,22 @@ export const organizeAudioPlaylists = playlists => {
       uri: ''
     };
 
+    if (typeof mainPlaylist === 'undefined' && role === 'main') {
+      mainPlaylist = playlist;
+      mainPlaylist.default = true;
+    }
+
     return a;
   }, {});
+
+  // if no playlists have role "main", mark the first as main
+  if (!mainPlaylist) {
+    const firstLabel = Object.keys(formattedPlaylists)[0];
+
+    formattedPlaylists[firstLabel].default = true;
+  }
+
+  return formattedPlaylists;
 };
 
 export const organizeVttPlaylists = playlists => {

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -13,7 +13,9 @@ const mergeDiscontiguousPlaylists = playlists => {
     // Periods after first
     if (acc[name]) {
       // first segment of subsequent periods signal a discontinuity
-      playlist.segments[0].discontinuity = true;
+      if (playlist.segments[0]) {
+        playlist.segments[0].discontinuity = true;
+      }
       acc[name].segments.push(...playlist.segments);
 
       // bubble up contentProtection, this assumes all DRM content

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -204,7 +204,7 @@ const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
   // Retain source duration from initial master manifest parsing
   const sourceDuration = playlist.segments[0].duration;
   // Retain source timeline
-  const timeline = playlist.timeline || 1;
+  const timeline = playlist.timeline || 0;
   const sidxByteRange = playlist.sidx.byterange;
   const sidxEnd = sidxByteRange.offset + sidxByteRange.length;
   // Retain timescale of the parsed sidx
@@ -231,6 +231,8 @@ const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
       baseUrl,
       timescale,
       timeline,
+      // this is used in parseByDuration
+      periodIndex: timeline,
       duration,
       indexRange
     };

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -234,6 +234,7 @@ const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
       // this is used in parseByDuration
       periodIndex: timeline,
       duration,
+      sourceDuration,
       indexRange
     };
 

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -199,6 +199,8 @@ export const formatVideoPlaylist = ({ attributes, segments, sidx }) => {
 };
 
 const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
+  // Retain init segment information
+  const initSegment = playlist.sidx.map ? playlist.sidx.map : null;
   // Retain source duration from initial master manifest parsing
   const sourceDuration = playlist.segments[0].duration;
   // Retain source timeline
@@ -233,16 +235,15 @@ const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
       indexRange
     };
 
-    // TODO: is there another way to see if there's an init segment here?
-    if (playlist.map) {
-      attributes.initialization = playlist.map;
-    }
-
     if (sourceDuration) {
       attributes.sourceDuration = sourceDuration;
     }
 
     const segment = segmentsFromBase(attributes)[0];
+
+    if (initSegment) {
+      segment.map = initSegment;
+    }
 
     // TODO: maybe it's better to just manually add the byte range here?
     // segment.byterange = {

--- a/src/toPlaylists.js
+++ b/src/toPlaylists.js
@@ -1,28 +1,42 @@
 import { merge } from './utils/object';
 import { segmentsFromTemplate } from './segment/segmentTemplate';
 import { segmentsFromList } from './segment/segmentList';
-import { segmentsFromBase } from './segment/segmentBase';
+import {
+  segmentsFromBase,
+  sidxFromBase
+} from './segment/segmentBase';
 
 export const generateSegments = ({ attributes, segmentInfo }) => {
   let segmentAttributes;
   let segmentsFn;
+  let sidxFn;
 
   if (segmentInfo.template) {
     segmentsFn = segmentsFromTemplate;
     segmentAttributes = merge(attributes, segmentInfo.template);
   } else if (segmentInfo.base) {
     segmentsFn = segmentsFromBase;
+    sidxFn = sidxFromBase;
     segmentAttributes = merge(attributes, segmentInfo.base);
   } else if (segmentInfo.list) {
     segmentsFn = segmentsFromList;
     segmentAttributes = merge(attributes, segmentInfo.list);
   }
 
+  const segmentsInfo = {
+    attributes
+  };
+
   if (!segmentsFn) {
-    return { attributes };
+    return segmentsInfo;
   }
 
   const segments = segmentsFn(segmentAttributes, segmentInfo.timeline);
+  let sidx;
+
+  if (sidxFn) {
+    sidx = sidxFn(segmentAttributes);
+  }
 
   // The @duration attribute will be used to determin the playlist's targetDuration which
   // must be in seconds. Since we've generated the segment list, we no longer need
@@ -41,10 +55,14 @@ export const generateSegments = ({ attributes, segmentInfo }) => {
     segmentAttributes.duration = 0;
   }
 
-  return {
-    attributes: segmentAttributes,
-    segments
-  };
+  segmentsInfo.attributes = segmentAttributes;
+  segmentsInfo.segments = segments;
+
+  if (sidx) {
+    segmentsInfo.sidx = sidx;
+  }
+
+  return segmentsInfo;
 };
 
 export const toPlaylists = (representations) => representations.map(generateSegments);

--- a/src/toPlaylists.js
+++ b/src/toPlaylists.js
@@ -2,21 +2,18 @@ import { merge } from './utils/object';
 import { segmentsFromTemplate } from './segment/segmentTemplate';
 import { segmentsFromList } from './segment/segmentList';
 import {
-  segmentsFromBase,
-  sidxFromBase
+  segmentsFromBase
 } from './segment/segmentBase';
 
 export const generateSegments = ({ attributes, segmentInfo }) => {
   let segmentAttributes;
   let segmentsFn;
-  let sidxFn;
 
   if (segmentInfo.template) {
     segmentsFn = segmentsFromTemplate;
     segmentAttributes = merge(attributes, segmentInfo.template);
   } else if (segmentInfo.base) {
     segmentsFn = segmentsFromBase;
-    sidxFn = sidxFromBase;
     segmentAttributes = merge(attributes, segmentInfo.base);
   } else if (segmentInfo.list) {
     segmentsFn = segmentsFromList;
@@ -32,11 +29,6 @@ export const generateSegments = ({ attributes, segmentInfo }) => {
   }
 
   const segments = segmentsFn(segmentAttributes, segmentInfo.timeline);
-  let sidx;
-
-  if (sidxFn) {
-    sidx = sidxFn(segmentAttributes);
-  }
 
   // The @duration attribute will be used to determin the playlist's targetDuration which
   // must be in seconds. Since we've generated the segment list, we no longer need
@@ -58,8 +50,10 @@ export const generateSegments = ({ attributes, segmentInfo }) => {
   segmentsInfo.attributes = segmentAttributes;
   segmentsInfo.segments = segments;
 
-  if (sidx) {
-    segmentsInfo.sidx = sidx;
+  // This is a sidx box without actual segment information
+  if (segmentInfo.base && segmentAttributes.indexRange) {
+    segmentsInfo.sidx = segments[0];
+    segmentsInfo.segments = [];
   }
 
   return segmentsInfo;

--- a/src/toPlaylists.js
+++ b/src/toPlaylists.js
@@ -1,9 +1,7 @@
 import { merge } from './utils/object';
 import { segmentsFromTemplate } from './segment/segmentTemplate';
 import { segmentsFromList } from './segment/segmentList';
-import {
-  segmentsFromBase
-} from './segment/segmentBase';
+import { segmentsFromBase } from './segment/segmentBase';
 
 export const generateSegments = ({ attributes, segmentInfo }) => {
   let segmentAttributes;

--- a/test/manifests/maat_vtt_segmentTemplate.js
+++ b/test/manifests/maat_vtt_segmentTemplate.js
@@ -76,9 +76,9 @@ export const parsedManifest = {
           }],
           uri: ''
         },
-        ['es (main)']: {
+        ['es']: {
           autoselect: true,
-          default: true,
+          default: false,
           language: 'es',
           playlists: [{
             attributes: {

--- a/test/segment/segmentBase.test.js
+++ b/test/segment/segmentBase.test.js
@@ -1,6 +1,7 @@
 import QUnit from 'qunit';
 import {
-  segmentsFromBase
+  segmentsFromBase,
+  addSegmentsToPlaylist
 } from '../../src/segment/segmentBase';
 import errors from '../../src/errors';
 
@@ -141,4 +142,53 @@ QUnit.test('translates ranges in <Initialization> node', function(assert) {
 
 QUnit.test('errors if no baseUrl exists', function(assert) {
   assert.throws(() => segmentsFromBase({}), new Error(errors.NO_BASE_URL));
+});
+
+QUnit.module('segmentBase - addSegmentsToPlaylist');
+
+QUnit.test('generates playlist from sidx references', function(assert) {
+  const baseUrl = 'http://www.example.com/i.fmp4';
+  const playlist = {
+    sidx: {
+      map: {
+        byterange: {
+          offset: 0,
+          length: 10
+        }
+      },
+      duration: 10,
+      byterange: {
+        offset: 9,
+        length: 11
+      }
+    },
+    segments: []
+  };
+  const sidx = {
+    timescale: 1,
+    firstOffset: 0,
+    references: [{
+      referenceType: 0,
+      referencedSize: 5,
+      subsegmentDuration: 2
+    }]
+  };
+
+  assert.deepEqual(addSegmentsToPlaylist(playlist, sidx, baseUrl).segments, [{
+    map: {
+      byterange: {
+        offset: 0,
+        length: 10
+      }
+    },
+    uri: 'http://www.example.com/i.fmp4',
+    resolvedUri: 'http://www.example.com/i.fmp4',
+    byterange: {
+      offset: 20,
+      length: 5
+    },
+    duration: 2,
+    timeline: 0,
+    number: 0
+  }]);
 });

--- a/test/segment/urlType.test.js
+++ b/test/segment/urlType.test.js
@@ -1,5 +1,8 @@
 import QUnit from 'qunit';
-import urlTypeConverter from '../../src/segment/urlType';
+import {
+  urlTypeToSegment as urlTypeConverter,
+  byteRangeToString
+} from '../../src/segment/urlType';
 
 QUnit.module('urlType - urlTypeConverter');
 
@@ -35,6 +38,21 @@ QUnit.test('returns correct object if given baseUrl, source and range', function
   });
 });
 
+QUnit.test('returns correct object if given baseUrl, source and indexRange', function(assert) {
+  assert.deepEqual(urlTypeConverter({
+    baseUrl: 'http://example.com',
+    source: 'sidx.fmp4',
+    indexRange: '101-105'
+  }), {
+    resolvedUri: 'http://example.com/sidx.fmp4',
+    uri: 'sidx.fmp4',
+    byterange: {
+      offset: 101,
+      length: 5
+    }
+  });
+});
+
 QUnit.test('returns correct object if given baseUrl and range', function(assert) {
   assert.deepEqual(urlTypeConverter({
     baseUrl: 'http://example.com',
@@ -47,4 +65,28 @@ QUnit.test('returns correct object if given baseUrl and range', function(assert)
       length: 5
     }
   });
+});
+
+QUnit.test('returns correct object if given baseUrl and indexRange', function(assert) {
+  assert.deepEqual(urlTypeConverter({
+    baseUrl: 'http://example.com',
+    indexRange: '101-105'
+  }), {
+    resolvedUri: 'http://example.com',
+    uri: '',
+    byterange: {
+      offset: 101,
+      length: 5
+    }
+  });
+});
+
+QUnit.module('urlType - byteRangeToString');
+
+QUnit.test('returns correct string representing byterange object', function(assert) {
+  assert.strictEqual(byteRangeToString({
+    offset: 0,
+    length: 100
+  }),
+  '0-99');
 });

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -459,6 +459,94 @@ QUnit.test('playlists with segments', function(assert) {
   assert.deepEqual(toM3u8(input), expected);
 });
 
+QUnit.test('playlists with sidx and sidxMapping', function(assert) {
+  const input = [{
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      periodIndex: 1,
+      mimeType: 'video/mp4'
+    },
+    segments: [],
+    sidx: {
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      uri: 'sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 10
+    },
+    uri: 'http://example.com/fmp4.mp4'
+  }];
+
+  const mapping = {
+    'sidx.mp4-10-19': {
+      sidx: {
+        timescale: 1,
+        firstOffset: 0,
+        references: [{
+          referenceType: 0,
+          referencedSize: 5,
+          subsegmentDuration: 2
+        }]
+      }
+    }
+  };
+
+  const expected = [{
+    attributes: {
+      AUDIO: 'audio',
+      SUBTITLES: 'subs',
+      BANDWIDTH: 10000,
+      CODECS: 'foo;bar',
+      NAME: '1',
+      ['PROGRAM-ID']: 1,
+      RESOLUTION: {
+        height: 600,
+        width: 800
+      }
+    },
+    sidx: {
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      uri: 'sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 10
+    },
+    targetDuration: 0,
+    timeline: 1,
+    uri: '',
+    segments: [{
+      map: {
+        resolvedUri: 'http://example.com/sidx.mp4',
+        uri: ''
+      },
+      byterange: {
+        offset: 20,
+        length: 5
+      },
+      uri: 'http://example.com/sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 2,
+      number: 0,
+      timeline: 1
+    }],
+    endList: true,
+    mediaSequence: 1,
+    resolvedUri: ''
+  }];
+
+  assert.deepEqual(toM3u8(input, mapping).playlists, expected);
+});
+
 QUnit.test('no playlists', function(assert) {
   assert.deepEqual(toM3u8([]), {});
 });

--- a/test/toPlaylists.test.js
+++ b/test/toPlaylists.test.js
@@ -71,6 +71,48 @@ QUnit.test('segment base', function(assert) {
   assert.deepEqual(toPlaylists(representations), playlists);
 });
 
+QUnit.test('segment base with sidx', function(assert) {
+  const representations = [{
+    attributes: {
+      baseUrl: 'http://example.com/',
+      periodIndex: 0,
+      sourceDuration: 2,
+      indexRange: '10-19'
+    },
+    segmentInfo: {
+      base: true
+    }
+  }];
+
+  const playlists = [{
+    attributes: {
+      baseUrl: 'http://example.com/',
+      periodIndex: 0,
+      sourceDuration: 2,
+      duration: 2,
+      indexRange: '10-19'
+    },
+    segments: [],
+    sidx: {
+      map: {
+        resolvedUri: 'http://example.com/',
+        uri: ''
+      },
+      resolvedUri: 'http://example.com/',
+      uri: 'http://example.com/',
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      timeline: 0,
+      duration: 2,
+      number: 0
+    }
+  }];
+
+  assert.deepEqual(toPlaylists(representations), playlists);
+});
+
 QUnit.test('segment list', function(assert) {
   const representations = [{
     attributes: {


### PR DESCRIPTION
Attempted fix for https://github.com/videojs/http-streaming/issues/162.

## Status
This appears to be working on the issue source.

## Changes proposed:
  - expose `sidxMapping` option on the `parse` method to allow modifying a complete master playlist with metadata from a parsed sidx box
  - attach a `sidx` property with byteRange references to manifest objects generated with SegmentBase. This applies to both video and audio playlists
  - replace media playlist segments with those generated from `sidx.references` when the `sidxMapping` option is given

## Sources
```
{ 
  src: "https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd",
  type: "application/dash+xml"
}
```

## To do
- [x] additional testing
- [x] add unit tests