### PR TITLE
fix: make byteRange.length inclusive

### DIFF
--- a/src/segment/urlType.js
+++ b/src/segment/urlType.js
@@ -20,7 +20,8 @@ import resolveUrl from '../utils/resolveUrl';
  *
  * @param {string} baseUrl - baseUrl provided by <BaseUrl> nodes
  * @param {string} source - source url for segment
- * @param {string} range - optional range used for range calls, follows
+ * @param {string} range - optional range used for range calls,
+ *   follows  RFC 2616, Clause 14.35.1
  * @return {SingleUri} full segment information transformed into a format similar
  *   to m3u8-parser
  */
@@ -35,8 +36,10 @@ export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '' }) => {
     const startRange = parseInt(ranges[0], 10);
     const endRange = parseInt(ranges[1], 10);
 
+    // byterange should be inclusive according to
+    // RFC 2616, Clause 14.35.1
     init.byterange = {
-      length: endRange - startRange,
+      length: endRange - startRange + 1,
       offset: startRange
     };
   }

--- a/test/segment/segmentBase.test.js
+++ b/test/segment/segmentBase.test.js
@@ -129,7 +129,7 @@ QUnit.test('translates ranges in <Initialization> node', function(assert) {
       resolvedUri: 'http://www.example.com/init.fmp4',
       uri: 'http://www.example.com/init.fmp4',
       byterange: {
-        length: 4,
+        length: 5,
         offset: 121
       }
     },

--- a/test/segment/segmentList.test.js
+++ b/test/segment/segmentList.test.js
@@ -425,7 +425,7 @@ QUnit.test('segmentUrl translates ranges correctly', function(assert) {
       uri: 'init.fmp4'
     },
     byterange: {
-      length: 200,
+      length: 201,
       offset: 0
     },
     resolvedUri: 'http://example.com/1.fmp4',
@@ -435,7 +435,7 @@ QUnit.test('segmentUrl translates ranges correctly', function(assert) {
   }, {
     duration: 10,
     byterange: {
-      length: 199,
+      length: 200,
       offset: 201
     },
     map: {
@@ -517,7 +517,7 @@ QUnit.test('translates ranges in <Initialization> node', function(assert) {
       resolvedUri: 'http://example.com/init.fmp4',
       uri: 'init.fmp4',
       byterange: {
-        length: 4,
+        length: 5,
         offset: 121
       }
     },
@@ -531,7 +531,7 @@ QUnit.test('translates ranges in <Initialization> node', function(assert) {
       resolvedUri: 'http://example.com/init.fmp4',
       uri: 'init.fmp4',
       byterange: {
-        length: 4,
+        length: 5,
         offset: 121
       }
     },

--- a/test/segment/segmentTemplate.test.js
+++ b/test/segment/segmentTemplate.test.js
@@ -1312,7 +1312,7 @@ QUnit.test('constructs simple segment list and with <Initialization> node', func
         resolvedUri: 'https://example.com/init.mp4',
         uri: 'init.mp4',
         byterange: {
-          length: 4,
+          length: 5,
           offset: 121
         }
       },
@@ -1327,7 +1327,7 @@ QUnit.test('constructs simple segment list and with <Initialization> node', func
         resolvedUri: 'https://example.com/init.mp4',
         uri: 'init.mp4',
         byterange: {
-          length: 4,
+          length: 5,
           offset: 121
         }
       },
@@ -1342,7 +1342,7 @@ QUnit.test('constructs simple segment list and with <Initialization> node', func
         resolvedUri: 'https://example.com/init.mp4',
         uri: 'init.mp4',
         byterange: {
-          length: 4,
+          length: 5,
           offset: 121
         }
       },

--- a/test/segment/urlType.test.js
+++ b/test/segment/urlType.test.js
@@ -30,7 +30,7 @@ QUnit.test('returns correct object if given baseUrl, source and range', function
     uri: 'init.fmp4',
     byterange: {
       offset: 101,
-      length: 4
+      length: 5
     }
   });
 });
@@ -44,7 +44,7 @@ QUnit.test('returns correct object if given baseUrl and range', function(assert)
     uri: '',
     byterange: {
       offset: 101,
-      length: 4
+      length: 5
     }
   });
 });


### PR DESCRIPTION
All byteRanges in DASH are inclusive as per https://tools.ietf.org/html/rfc2616#section-14.35.1.