### PR TITLE
fix: skip playlists without sidx

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -47,6 +47,11 @@ const addSegmentInfoFromSidx = (playlists, sidxMapping = {}) => {
 
   for (const i in playlists) {
     const playlist = playlists[i];
+
+    if (!playlist.sidx) {
+      continue;
+    }
+
     const sidxKey = playlist.sidx.uri + '-' +
       byteRangeToString(playlist.sidx.byterange);
     const sidxMatch = sidxMapping[sidxKey] && sidxMapping[sidxKey].sidx;


### PR DESCRIPTION
This can be when we have an mpd with captions without SIDX and video segments that use SIDX, like in ihttps://dash.edgesuite.net/akamai/test/caption_test/ElephantsDream/elephants_dream_480p_heaac5_1.mpd.

Fixes videojs/video.js#5289