### PR TITLE
fix: don't adjust mediaPresentationDuration by timescale for segment …

### DIFF
--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -17,7 +17,6 @@ export const segmentsFromBase = (attributes) => {
     baseUrl,
     initialization = {},
     sourceDuration,
-    timescale = 1,
     indexRange = '',
     duration
   } = attributes;
@@ -47,7 +46,7 @@ export const segmentsFromBase = (attributes) => {
       segment.timeline = segmentTimeInfo[0].timeline;
     }
   } else if (sourceDuration) {
-    segment.duration = (sourceDuration / timescale);
+    segment.duration = sourceDuration;
     segment.timeline = 0;
   }
 

--- a/test/segment/segmentBase.test.js
+++ b/test/segment/segmentBase.test.js
@@ -44,7 +44,14 @@ QUnit.test('sets duration based on sourceDuration', function(assert) {
   }]);
 });
 
-QUnit.test('sets duration based on sourceDuration and @timescale', function(assert) {
+// sourceDuration comes from mediaPresentationDuration. The DASH spec defines the type of
+// mediaPresentationDuration as xs:duration, which follows ISO 8601. It does not need to
+// be adjusted based on timescale.
+//
+// References:
+// https://www.w3.org/TR/xmlschema-2/#duration
+// https://en.wikipedia.org/wiki/ISO_8601
+QUnit.test('sets duration based on sourceDuration and not @timescale', function(assert) {
   const inputAttributes = {
     baseUrl: 'http://www.example.com/i.fmp4',
     initialization: { sourceURL: 'http://www.example.com/init.fmp4' },
@@ -53,7 +60,7 @@ QUnit.test('sets duration based on sourceDuration and @timescale', function(asse
   };
 
   assert.deepEqual(segmentsFromBase(inputAttributes), [{
-    duration: 5,
+    duration: 10,
     timeline: 0,
     map: {
       resolvedUri: 'http://www.example.com/init.fmp4',


### PR DESCRIPTION
…duration when using SegmentBase

When using SegmentBase, there is only one segment. If the duration is
not present, sourceDuration is used, which comes from
mediaPresentationDuration.

Previously, sourceDuration was being divided by the timescale, but
mediaPresentationDuration is defined in the DASH spec as s:duration,
which follows ISO 8601. It doesn't need to be adjusted based on the
timescale.

This change fixes the use of sourceDuration for SegmentBase by not
performing that division.