### PR TITLE
feat: remove default value of 0 for minimumUpdatePeriod

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -241,7 +241,7 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
     sourceDuration: duration,
     type = 'static',
     suggestedPresentationDelay,
-    minimumUpdatePeriod = 0
+    minimumUpdatePeriod
   } = dashPlaylists[0].attributes;
 
   const videoOnly = ({ attributes }) =>
@@ -268,9 +268,12 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
     },
     uri: '',
     duration,
-    playlists: addSegmentInfoFromSidx(videoPlaylists, sidxMapping),
-    minimumUpdatePeriod: minimumUpdatePeriod * 1000
+    playlists: addSegmentInfoFromSidx(videoPlaylists, sidxMapping)
   };
+
+  if (minimumUpdatePeriod >= 0) {
+    master.minimumUpdatePeriod = minimumUpdatePeriod * 1000;
+  }
 
   if (locations) {
     master.locations = locations;

--- a/test/manifests/location.js
+++ b/test/manifests/location.js
@@ -6,7 +6,6 @@ export const parsedManifest = {
   discontinuityStarts: [],
   duration: 6,
   endList: true,
-  minimumUpdatePeriod: 0,
   mediaGroups: {
     'AUDIO': {},
     'CLOSED-CAPTIONS': {},

--- a/test/manifests/locations.js
+++ b/test/manifests/locations.js
@@ -7,7 +7,6 @@ export const parsedManifest = {
   discontinuityStarts: [],
   duration: 6,
   endList: true,
-  minimumUpdatePeriod: 0,
   mediaGroups: {
     'AUDIO': {},
     'CLOSED-CAPTIONS': {},

--- a/test/manifests/maat_vtt_segmentTemplate.js
+++ b/test/manifests/maat_vtt_segmentTemplate.js
@@ -3,7 +3,6 @@ export const parsedManifest = {
   discontinuityStarts: [],
   duration: 6,
   endList: true,
-  minimumUpdatePeriod: 0,
   mediaGroups: {
     AUDIO: {
       audio: {

--- a/test/manifests/multiperiod-dynamic.js
+++ b/test/manifests/multiperiod-dynamic.js
@@ -948,6 +948,5 @@ export const parsedManifest = {
       }
     }
   }],
-  minimumUpdatePeriod: 0,
   suggestedPresentationDelay: 18
 };

--- a/test/manifests/multiperiod.js
+++ b/test/manifests/multiperiod.js
@@ -947,6 +947,5 @@ export const parsedManifest = {
         pssh: new Uint8Array([181, 235, 45])
       }
     }
-  }],
-  minimumUpdatePeriod: 0
+  }]
 };

--- a/test/manifests/segmentBase.js
+++ b/test/manifests/segmentBase.js
@@ -3,7 +3,6 @@ export const parsedManifest = {
   discontinuityStarts: [],
   duration: 6,
   endList: true,
-  minimumUpdatePeriod: 0,
   mediaGroups: {
     'AUDIO': {},
     'CLOSED-CAPTIONS': {},

--- a/test/manifests/segmentList.js
+++ b/test/manifests/segmentList.js
@@ -3,7 +3,6 @@ export const parsedManifest = {
   discontinuityStarts: [],
   duration: 6,
   endList: true,
-  minimumUpdatePeriod: 0,
   mediaGroups: {
     'AUDIO': {},
     'CLOSED-CAPTIONS': {},

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -571,7 +571,7 @@ QUnit.test('playlists without minimumUpdatePeriod dont assign default value', fu
     uri: 'http://example.com/fmp4.mp4'
   }];
 
-  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, undefined);
+  assert.equal(toM3u8(input).minimumUpdatePeriod, undefined);
 });
 
 QUnit.test('playlists with minimumUpdatePeriod = 0', function(assert) {
@@ -601,7 +601,7 @@ QUnit.test('playlists with minimumUpdatePeriod = 0', function(assert) {
     uri: 'http://example.com/fmp4.mp4'
   }];
 
-  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, 0);
+  assert.equal(toM3u8(input).minimumUpdatePeriod, 0);
 });
 
 QUnit.test('playlists with integer value for minimumUpdatePeriod', function(assert) {
@@ -631,7 +631,7 @@ QUnit.test('playlists with integer value for minimumUpdatePeriod', function(asse
     uri: 'http://example.com/fmp4.mp4'
   }];
 
-  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, 2000, 'converts update period to ms');
+  assert.equal(toM3u8(input).minimumUpdatePeriod, 2000, 'converts update period to ms');
 });
 
 QUnit.test('no playlists', function(assert) {

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -64,7 +64,6 @@ QUnit.test('playlists', function(assert) {
     discontinuityStarts: [],
     duration: 100,
     endList: true,
-    minimumUpdatePeriod: 0,
     mediaGroups: {
       AUDIO: {
         audio: {
@@ -317,7 +316,6 @@ QUnit.test('playlists with segments', function(assert) {
     discontinuityStarts: [],
     duration: 100,
     endList: true,
-    minimumUpdatePeriod: 0,
     mediaGroups: {
       AUDIO: {
         audio: {
@@ -545,6 +543,95 @@ QUnit.test('playlists with sidx and sidxMapping', function(assert) {
   }];
 
   assert.deepEqual(toM3u8(input, null, mapping).playlists, expected);
+});
+
+QUnit.test('playlists without minimumUpdatePeriod dont assign default value', function(assert) {
+  const input = [{
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      periodIndex: 1,
+      mimeType: 'video/mp4'
+    },
+    segments: [],
+    sidx: {
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      uri: 'sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 10
+    },
+    uri: 'http://example.com/fmp4.mp4'
+  }];
+
+  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, undefined);
+});
+
+QUnit.test('playlists with minimumUpdatePeriod = 0', function(assert) {
+  const input = [{
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      periodIndex: 1,
+      mimeType: 'video/mp4',
+      minimumUpdatePeriod: 0
+    },
+    segments: [],
+    sidx: {
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      uri: 'sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 10
+    },
+    uri: 'http://example.com/fmp4.mp4'
+  }];
+
+  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, 0);
+});
+
+QUnit.test('playlists with integer value for minimumUpdatePeriod', function(assert) {
+  const input = [{
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      periodIndex: 1,
+      mimeType: 'video/mp4',
+      minimumUpdatePeriod: 2
+    },
+    segments: [],
+    sidx: {
+      byterange: {
+        offset: 10,
+        length: 10
+      },
+      uri: 'sidx.mp4',
+      resolvedUri: 'http://example.com/sidx.mp4',
+      duration: 10
+    },
+    uri: 'http://example.com/fmp4.mp4'
+  }];
+
+  assert.deepEqual(toM3u8(input).minimumUpdatePeriod, 2000, 'converts update period to ms');
 });
 
 QUnit.test('no playlists', function(assert) {


### PR DESCRIPTION
## Description
We cannot currently differentiate between cases when the `minimumUpdatePeriod` does not exist vs. when it is 0, since we set 0 as the default value in the first case. Since it is valid for the `minimumUpdatePeriod` to be either 0 or absent, we need to remove this default value.