### PR TITLE
feat: subtitle codecs

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 <body>
   <p>Open dev tools to try it out</p>
   <ul>
-    <li><a id="test/debug.html">Run unit tests in browser.</a></li>
-    <li><a id="docs" href="docs/api/">Read generated docs.</a></li>
+    <li><a href="test/debug.html">Run unit tests in browser.</a></li>
+    <li><a href="docs/api/">Read generated docs.</a></li>
   </ul>
 
   <form id=parse>

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -105,13 +105,18 @@ export const formatVttPlaylist = ({ attributes, segments }) => {
     // targetDuration should be the same duration as the only segment
     attributes.duration = attributes.sourceDuration;
   }
+
+  const m3u8Attributes = {
+    NAME: attributes.id,
+    BANDWIDTH: attributes.bandwidth,
+    ['PROGRAM-ID']: 1
+  };
+
+  if (attributes.codecs) {
+    m3u8Attributes.CODECS = attributes.codecs;
+  }
   return {
-    attributes: {
-      NAME: attributes.id,
-      BANDWIDTH: attributes.bandwidth,
-      CODECS: attributes.codecs,
-      ['PROGRAM-ID']: 1
-    },
+    attributes: m3u8Attributes,
     uri: '',
     endList: (attributes.type || 'static') === 'static',
     timeline: attributes.periodIndex,

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -109,6 +109,7 @@ export const formatVttPlaylist = ({ attributes, segments }) => {
     attributes: {
       NAME: attributes.id,
       BANDWIDTH: attributes.bandwidth,
+      CODECS: attributes.codecs,
       ['PROGRAM-ID']: 1
     },
     uri: '',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,10 @@
 import { parse, VERSION } from '../src';
 import QUnit from 'qunit';
 
+QUnit.dump.maxDepth = Infinity;
+
 // manifests
+import vttCodecsTemplate from './manifests/vtt_codecs.mpd';
 import maatVttSegmentTemplate from './manifests/maat_vtt_segmentTemplate.mpd';
 import segmentBaseTemplate from './manifests/segmentBase.mpd';
 import segmentListTemplate from './manifests/segmentList.mpd';
@@ -30,6 +33,10 @@ import {
 import {
   parsedManifest as locationsManifest
 } from './manifests/locations.js';
+
+import {
+  parsedManifest as vttCodecsManifest
+} from './manifests/vtt_codecs.js';
 
 QUnit.module('mpd-parser');
 
@@ -69,6 +76,10 @@ QUnit.test('has parse', function(assert) {
   name: 'locations',
   input: locationsTemplate,
   expected: locationsManifest
+}, {
+  name: 'vtt_codecs',
+  input: vttCodecsTemplate,
+  expected: vttCodecsManifest
 }].forEach(({ name, input, expected }) => {
   QUnit.test(`${name} test manifest`, function(assert) {
     const actual = parse(input);

--- a/test/manifests/vtt_codecs.js
+++ b/test/manifests/vtt_codecs.js
@@ -1,0 +1,348 @@
+export const parsedManifest = {
+  allowCache: true,
+  discontinuityStarts: [],
+  duration: 6,
+  endList: true,
+  mediaGroups: {
+    AUDIO: {
+      audio: {
+        ['en (main)']: {
+          autoselect: true,
+          default: true,
+          language: 'en',
+          playlists: [{
+            attributes: {
+              BANDWIDTH: 125000,
+              CODECS: 'mp4a.40.2',
+              NAME: '125000',
+              ['PROGRAM-ID']: 1
+            },
+            contentProtection: {
+              'com.widevine.alpha': {
+                attributes: {
+                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                },
+                pssh: new Uint8Array([181, 235, 45])
+              }
+            },
+            endList: true,
+            mediaSequence: 0,
+            targetDuration: 1.984,
+            resolvedUri: '',
+            segments: [{
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/init.m4f',
+                uri: '125000/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/0.m4f',
+              timeline: 0,
+              uri: '125000/0.m4f',
+              number: 0
+            }, {
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/init.m4f',
+                uri: '125000/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/1.m4f',
+              timeline: 0,
+              uri: '125000/1.m4f',
+              number: 1
+            }, {
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/init.m4f',
+                uri: '125000/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/2.m4f',
+              timeline: 0,
+              uri: '125000/2.m4f',
+              number: 2
+            }, {
+              duration: 0.04800000000000004,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/init.m4f',
+                uri: '125000/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/3.m4f',
+              timeline: 0,
+              uri: '125000/3.m4f',
+              number: 3
+            }],
+            timeline: 0,
+            uri: ''
+          }],
+          uri: ''
+        },
+        ['es']: {
+          autoselect: true,
+          default: false,
+          language: 'es',
+          playlists: [{
+            attributes: {
+              BANDWIDTH: 125000,
+              CODECS: 'mp4a.40.2',
+              NAME: '125000',
+              ['PROGRAM-ID']: 1
+            },
+            contentProtection: {
+              'com.widevine.alpha': {
+                attributes: {
+                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                },
+                pssh: new Uint8Array([181, 235, 45])
+              }
+            },
+            endList: true,
+            targetDuration: 1.984,
+            mediaSequence: 0,
+            resolvedUri: '',
+            segments: [{
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
+                uri: '125000/es/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/es/0.m4f',
+              timeline: 0,
+              uri: '125000/es/0.m4f',
+              number: 0
+            }, {
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
+                uri: '125000/es/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/es/1.m4f',
+              timeline: 0,
+              uri: '125000/es/1.m4f',
+              number: 1
+            }, {
+              duration: 1.984,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
+                uri: '125000/es/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/es/2.m4f',
+              timeline: 0,
+              uri: '125000/es/2.m4f',
+              number: 2
+            }, {
+              duration: 0.04800000000000004,
+              map: {
+                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
+                uri: '125000/es/init.m4f'
+              },
+              resolvedUri: 'https://www.example.com/125000/es/3.m4f',
+              timeline: 0,
+              uri: '125000/es/3.m4f',
+              number: 3
+            }],
+            timeline: 0,
+            uri: ''
+          }],
+          uri: ''
+        }
+      }
+    },
+    ['CLOSED-CAPTIONS']: {},
+    SUBTITLES: {
+      subs: {
+        en: {
+          autoselect: false,
+          default: false,
+          language: 'en',
+          playlists: [{
+            attributes: {
+              BANDWIDTH: 256,
+              NAME: 'en',
+              CODECS: 'stpp.ttml.im1t',
+              ['PROGRAM-ID']: 1
+            },
+            mediaSequence: 0,
+            endList: true,
+            targetDuration: 6,
+            resolvedUri: 'https://example.com/en.dash',
+            segments: [{
+              duration: 6,
+              resolvedUri: 'https://example.com/en.dash',
+              timeline: 0,
+              uri: 'https://example.com/en.dash',
+              number: 0
+            }],
+            timeline: 0,
+            uri: ''
+          }],
+          uri: ''
+        },
+        es: {
+          autoselect: false,
+          default: false,
+          language: 'es',
+          playlists: [{
+            attributes: {
+              BANDWIDTH: 256,
+              NAME: 'es',
+              ['PROGRAM-ID']: 1
+            },
+            endList: true,
+            targetDuration: 6,
+            mediaSequence: 0,
+            resolvedUri: 'https://example.com/es.vtt',
+            segments: [{
+              duration: 6,
+              resolvedUri: 'https://example.com/es.vtt',
+              timeline: 0,
+              uri: 'https://example.com/es.vtt',
+              number: 0
+            }],
+            timeline: 0,
+            uri: ''
+          }],
+          uri: ''
+        }
+      }
+    },
+    VIDEO: {}
+  },
+  playlists: [{
+    attributes: {
+      AUDIO: 'audio',
+      SUBTITLES: 'subs',
+      BANDWIDTH: 449000,
+      CODECS: 'avc1.420015',
+      NAME: '482',
+      ['PROGRAM-ID']: 1,
+      RESOLUTION: {
+        height: 270,
+        width: 482
+      }
+    },
+    contentProtection: {
+      'com.widevine.alpha': {
+        attributes: {
+          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+        },
+        pssh: new Uint8Array([181, 235, 45])
+      }
+    },
+    endList: true,
+    targetDuration: 1.9185833333333333,
+    mediaSequence: 0,
+    resolvedUri: '',
+    segments: [{
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/482/init.m4f',
+        uri: '482/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/482/0.m4f',
+      timeline: 0,
+      uri: '482/0.m4f',
+      number: 0
+    }, {
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/482/init.m4f',
+        uri: '482/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/482/1.m4f',
+      timeline: 0,
+      uri: '482/1.m4f',
+      number: 1
+    }, {
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/482/init.m4f',
+        uri: '482/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/482/2.m4f',
+      timeline: 0,
+      uri: '482/2.m4f',
+      number: 2
+    }, {
+      duration: 0.24425000000000008,
+      map: {
+        resolvedUri: 'https://www.example.com/482/init.m4f',
+        uri: '482/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/482/3.m4f',
+      timeline: 0,
+      uri: '482/3.m4f',
+      number: 3
+    }],
+    timeline: 0,
+    uri: ''
+  }, {
+    attributes: {
+      AUDIO: 'audio',
+      SUBTITLES: 'subs',
+      BANDWIDTH: 3971000,
+      CODECS: 'avc1.64001e',
+      NAME: '720',
+      ['PROGRAM-ID']: 1,
+      RESOLUTION: {
+        height: 404,
+        width: 720
+      }
+    },
+    contentProtection: {
+      'com.widevine.alpha': {
+        attributes: {
+          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+        },
+        pssh: new Uint8Array([181, 235, 45])
+      }
+    },
+    endList: true,
+    targetDuration: 1.9185833333333333,
+    mediaSequence: 0,
+    resolvedUri: '',
+    segments: [{
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/720/init.m4f',
+        uri: '720/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/720/0.m4f',
+      timeline: 0,
+      uri: '720/0.m4f',
+      number: 0
+    }, {
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/720/init.m4f',
+        uri: '720/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/720/1.m4f',
+      timeline: 0,
+      uri: '720/1.m4f',
+      number: 1
+    }, {
+      duration: 1.9185833333333333,
+      map: {
+        resolvedUri: 'https://www.example.com/720/init.m4f',
+        uri: '720/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/720/2.m4f',
+      timeline: 0,
+      uri: '720/2.m4f',
+      number: 2
+    }, {
+      duration: 0.24425000000000008,
+      map: {
+        resolvedUri: 'https://www.example.com/720/init.m4f',
+        uri: '720/init.m4f'
+      },
+      resolvedUri: 'https://www.example.com/720/3.m4f',
+      timeline: 0,
+      uri: '720/3.m4f',
+      number: 3
+    }],
+    timeline: 0,
+    uri: ''
+  }],
+  segments: [],
+  uri: ''
+};

--- a/test/manifests/vtt_codecs.mpd
+++ b/test/manifests/vtt_codecs.mpd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT6S" minBufferTime="PT2.000S">
+  <BaseURL>https://www.example.com/base</BaseURL>
+  <Period>
+
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en">
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="aaa"/>
+      <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh>test</cenc:pssh>
+      </ContentProtection>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"></Role>
+      <SegmentTemplate duration="95232" initialization="$RepresentationID$/init.m4f" media="$RepresentationID$/$Number$.m4f" startNumber="0" timescale="48000"></SegmentTemplate>
+      <Representation audioSamplingRate="48000" bandwidth="63000" codecs="mp4a.40.2" id="63000">
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="125000" codecs="mp4a.40.2" id="125000">
+      </Representation>
+    </AdaptationSet>
+
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="es">
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="aaa"/>
+      <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh>test</cenc:pssh>
+      </ContentProtection>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011"></Role>
+      <SegmentTemplate duration="95232" initialization="$RepresentationID$/es/init.m4f" media="$RepresentationID$/es/$Number$.m4f" startNumber="0" timescale="48000"></SegmentTemplate>
+      <Representation audioSamplingRate="48000" bandwidth="63000" codecs="mp4a.40.2" id="63000">
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="125000" codecs="mp4a.40.2" id="125000">
+      </Representation>
+    </AdaptationSet>
+
+    <AdaptationSet mimeType="video/mp4" scanType="progressive" segmentAlignment="true" startWithSAP="1">
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="aaa"/>
+      <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh>test</cenc:pssh>
+      </ContentProtection>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"></Role>
+      <SegmentTemplate duration="46046" initialization="$RepresentationID$/init.m4f" media="$RepresentationID$/$Number$.m4f" startNumber="0" timescale="24000"></SegmentTemplate>
+      <Representation bandwidth="449000" codecs="avc1.420015" frameRate="2997/125" height="270" id="482" width="482">
+      </Representation>
+      <Representation bandwidth="3971000" codecs="avc1.64001e" frameRate="2997/125" height="404" id="720" width="720">
+      </Representation>
+    </AdaptationSet>
+
+    <AdaptationSet contentType="text" mimeType="application/mp4" lang="en" codecs="stpp.ttml.im1t">
+      <Representation bandwidth="256" id="en">
+        <BaseURL>https://example.com/en.dash</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="text/vtt" lang="es">
+      <Representation bandwidth="256" id="es">
+        <BaseURL>https://example.com/es.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+
+  </Period>
+</MPD>


### PR DESCRIPTION
We have a test video that uses non-vtt captions that is making it all the way through to the vtt segment loader. We cannot filter it as we don't expose CODECS on subtitle playlists. Now we expose that so we can filter downstream. We might also want to expose mimeType?