### PR TITLE
test: fix tests introduced in #79 that was not rebased on #103

### DIFF
--- a/test/manifests/webmsegments.js
+++ b/test/manifests/webmsegments.js
@@ -149,6 +149,5 @@ export const parsedManifest = {
       ],
       mediaSequence: 0
     }
-  ],
-  minimumUpdatePeriod: 0
+  ]
 };


### PR DESCRIPTION
The default for `minimumUpdatePeriod` was removed in #103 