### PR TITLE
fix: fix edge case error handling on ie 11

### DIFF
--- a/src/stringToMpdXml.js
+++ b/src/stringToMpdXml.js
@@ -7,9 +7,16 @@ export const stringToMpdXml = (manifestString) => {
   }
 
   const parser = new DOMParser();
-  const xml = parser.parseFromString(manifestString, 'application/xml');
-  const mpd = xml && xml.documentElement.tagName === 'MPD' ?
-    xml.documentElement : null;
+  let xml;
+  let mpd;
+
+  try {
+    xml = parser.parseFromString(manifestString, 'application/xml');
+    mpd = xml && xml.documentElement.tagName === 'MPD' ?
+      xml.documentElement : null;
+  } catch (e) {
+    // ie 11 throwsw on invalid xml
+  }
 
   if (!mpd || mpd &&
       mpd.getElementsByTagName('parsererror').length > 0) {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -6,6 +6,10 @@ export const merge = (...objects) => {
 
   return objects.reduce((result, source) => {
 
+    if (typeof source !== 'object') {
+      return result;
+    }
+
     Object.keys(source).forEach(key => {
 
       if (Array.isArray(result[key]) && Array.isArray(source[key])) {


### PR DESCRIPTION
Apparently we never set up browserstack for this project so we only ever tested on chrome/firefox/nodejs. With the switch to github ci in #111 ie 11 started to fail.