### PR TITLE
fix: export generateSidxKey, multiple audio/vtt playlists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import { version } from '../package.json';
-import { toM3u8 } from './toM3u8';
+import { toM3u8, generateSidxKey } from './toM3u8';
 import { toPlaylists } from './toPlaylists';
 import { inheritAttributes } from './inheritAttributes';
 import { stringToMpdXml } from './stringToMpdXml';
 import { parseUTCTimingScheme } from './parseUTCTimingScheme';
-import {addSegmentsToPlaylist} from './segment/segmentBase.js';
+import {addSidxSegmentsToPlaylist} from './segment/segmentBase.js';
 
 const VERSION = version;
 
@@ -26,8 +26,6 @@ const parse = (manifestString, options = {}) => {
 const parseUTCTiming = (manifestString) =>
   parseUTCTimingScheme(stringToMpdXml(manifestString));
 
-const addSidxSegmentsToPlaylist = addSegmentsToPlaylist;
-
 export {
   VERSION,
   parse,
@@ -36,5 +34,6 @@ export {
   inheritAttributes,
   toPlaylists,
   toM3u8,
-  addSidxSegmentsToPlaylist
+  addSidxSegmentsToPlaylist,
+  generateSidxKey
 };

--- a/src/segment/segmentBase.js
+++ b/src/segment/segmentBase.js
@@ -67,7 +67,7 @@ export const segmentsFromBase = (attributes) => {
  * @param {Object} sidx the parsed sidx box
  * @return {Object} the playlist object with the updated sidx information
  */
-export const addSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
+export const addSidxSegmentsToPlaylist = (playlist, sidx, baseUrl) => {
   // Retain init segment information
   const initSegment = playlist.sidx.map ? playlist.sidx.map : null;
   // Retain source duration from initial master manifest parsing

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -1,7 +1,10 @@
 import { values } from './utils/object';
 import { findIndexes } from './utils/list';
-import { addSegmentsToPlaylist } from './segment/segmentBase';
+import { addSidxSegmentsToPlaylist as addSidxSegmentsToPlaylist_ } from './segment/segmentBase';
 import { byteRangeToString } from './segment/urlType';
+
+export const generateSidxKey = (sidx) => sidx &&
+  sidx.uri + '-' + byteRangeToString(sidx.byterange);
 
 const mergeDiscontiguousPlaylists = playlists => {
   const mergedPlaylists = values(playlists.reduce((acc, playlist) => {
@@ -40,25 +43,24 @@ const mergeDiscontiguousPlaylists = playlists => {
   });
 };
 
-const addSegmentInfoFromSidx = (playlists, sidxMapping = {}) => {
+export const addSidxSegmentsToPlaylist = (playlist, sidxMapping) => {
+  const sidxKey = generateSidxKey(playlist.sidx);
+  const sidxMatch = sidxKey && sidxMapping[sidxKey] && sidxMapping[sidxKey].sidx;
+
+  if (sidxMatch) {
+    addSidxSegmentsToPlaylist_(playlist, sidxMatch, playlist.sidx.resolvedUri);
+  }
+
+  return playlist;
+};
+
+export const addSidxSegmentsToPlaylists = (playlists, sidxMapping = {}) => {
   if (!Object.keys(sidxMapping).length) {
     return playlists;
   }
 
   for (const i in playlists) {
-    const playlist = playlists[i];
-
-    if (!playlist.sidx) {
-      continue;
-    }
-
-    const sidxKey = playlist.sidx.uri + '-' +
-      byteRangeToString(playlist.sidx.byterange);
-    const sidxMatch = sidxMapping[sidxKey] && sidxMapping[sidxKey].sidx;
-
-    if (playlist.sidx && sidxMatch) {
-      addSegmentsToPlaylist(playlist, sidxMatch, playlist.sidx.resolvedUri);
-    }
+    playlists[i] = addSidxSegmentsToPlaylist(playlists[i], sidxMapping);
   }
 
   return playlists;
@@ -143,23 +145,17 @@ export const organizeAudioPlaylists = (playlists, sidxMapping = {}) => {
       label = `${playlist.attributes.lang}${roleLabel}`;
     }
 
-    // skip if we already have the highest quality audio for a language
-    if (a[label] &&
-      a[label].playlists[0].attributes.BANDWIDTH >
-      playlist.attributes.bandwidth) {
-      return a;
+    if (!a[label]) {
+      a[label] = {
+        language,
+        autoselect: true,
+        default: role === 'main',
+        playlists: [],
+        uri: ''
+      };
     }
 
-    a[label] = {
-      language,
-      autoselect: true,
-      default: role === 'main',
-      playlists: addSegmentInfoFromSidx(
-        [formatAudioPlaylist(playlist)],
-        sidxMapping
-      ),
-      uri: ''
-    };
+    a[label].playlists.push(addSidxSegmentsToPlaylist(formatAudioPlaylist(playlist), sidxMapping));
 
     if (typeof mainPlaylist === 'undefined' && role === 'main') {
       mainPlaylist = playlist;
@@ -183,21 +179,16 @@ export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
     const label = playlist.attributes.lang || 'text';
 
-    // skip if we already have subtitles
-    if (a[label]) {
-      return a;
+    if (!a[label]) {
+      a[label] = {
+        language: label,
+        default: false,
+        autoselect: false,
+        playlists: [],
+        uri: ''
+      };
     }
-
-    a[label] = {
-      language: label,
-      default: false,
-      autoselect: false,
-      playlists: addSegmentInfoFromSidx(
-        [formatVttPlaylist(playlist)],
-        sidxMapping
-      ),
-      uri: ''
-    };
+    a[label].playlists.push(addSidxSegmentsToPlaylist(formatVttPlaylist(playlist), sidxMapping));
 
     return a;
   }, {});
@@ -237,6 +228,13 @@ export const formatVideoPlaylist = ({ attributes, segments, sidx }) => {
   return playlist;
 };
 
+const videoOnly = ({ attributes }) =>
+  attributes.mimeType === 'video/mp4' || attributes.mimeType === 'video/webm' || attributes.contentType === 'video';
+const audioOnly = ({ attributes }) =>
+  attributes.mimeType === 'audio/mp4' || attributes.mimeType === 'audio/webm' || attributes.contentType === 'audio';
+const vttOnly = ({ attributes }) =>
+  attributes.mimeType === 'text/vtt' || attributes.contentType === 'text';
+
 export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
   if (!dashPlaylists.length) {
     return {};
@@ -249,13 +247,6 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
     suggestedPresentationDelay,
     minimumUpdatePeriod
   } = dashPlaylists[0].attributes;
-
-  const videoOnly = ({ attributes }) =>
-    attributes.mimeType === 'video/mp4' || attributes.mimeType === 'video/webm' || attributes.contentType === 'video';
-  const audioOnly = ({ attributes }) =>
-    attributes.mimeType === 'audio/mp4' || attributes.mimeType === 'audio/webm' || attributes.contentType === 'audio';
-  const vttOnly = ({ attributes }) =>
-    attributes.mimeType === 'text/vtt' || attributes.contentType === 'text';
 
   const videoPlaylists = mergeDiscontiguousPlaylists(dashPlaylists.filter(videoOnly)).map(formatVideoPlaylist);
   const audioPlaylists = mergeDiscontiguousPlaylists(dashPlaylists.filter(audioOnly));
@@ -274,7 +265,7 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
     },
     uri: '',
     duration,
-    playlists: addSegmentInfoFromSidx(videoPlaylists, sidxMapping)
+    playlists: addSidxSegmentsToPlaylists(videoPlaylists, sidxMapping)
   };
 
   if (minimumUpdatePeriod >= 0) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@ import locationsTemplate from './manifests/locations.mpd';
 import multiperiod from './manifests/multiperiod.mpd';
 import webmsegments from './manifests/webmsegments.mpd';
 import multiperiodDynamic from './manifests/multiperiod-dynamic.mpd';
+import audioOnly from './manifests/audio-only.mpd';
 import {
   parsedManifest as maatVttSegmentTemplateManifest
 } from './manifests/maat_vtt_segmentTemplate.js';
@@ -41,6 +42,10 @@ import {
 import {
   parsedManifest as vttCodecsManifest
 } from './manifests/vtt_codecs.js';
+
+import {
+  parsedManifest as audioOnlyManifest
+} from './manifests/audio-only.js';
 
 QUnit.module('mpd-parser');
 
@@ -88,6 +93,10 @@ QUnit.test('has parse', function(assert) {
   name: 'vtt_codecs',
   input: vttCodecsTemplate,
   expected: vttCodecsManifest
+}, {
+  name: 'audio-only',
+  input: audioOnly,
+  expected: audioOnlyManifest
 }].forEach(({ name, input, expected }) => {
   QUnit.test(`${name} test manifest`, function(assert) {
     const actual = parse(input);

--- a/test/manifests/audio-only.js
+++ b/test/manifests/audio-only.js
@@ -1,0 +1,106 @@
+export const parsedManifest = {
+  allowCache: true,
+  discontinuityStarts: [],
+  segments: [],
+  endList: true,
+  mediaGroups: {
+    'AUDIO': {
+      audio: {
+        en: {
+          language: 'en',
+          autoselect: true,
+          default: true,
+          playlists: [
+            {
+              attributes: {
+                'NAME': '0',
+                'BANDWIDTH': 130803,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1,
+                'AUDIO': 'audio',
+                'SUBTITLES': 'subs'
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 60,
+              segments: [],
+              mediaSequence: 1,
+              sidx: {
+                uri: 'http://example.com/audio_en_2c_128k_aac.mp4',
+                resolvedUri: 'http://example.com/audio_en_2c_128k_aac.mp4',
+                byterange: {
+                  length: 224,
+                  offset: 786
+                },
+                map: {
+                  uri: '',
+                  resolvedUri: 'http://example.com/audio_en_2c_128k_aac.mp4',
+                  byterange: {
+                    length: 786,
+                    offset: 0
+                  }
+                },
+                duration: 60,
+                timeline: 0,
+                number: 0
+              }
+            }
+          ],
+          uri: ''
+        },
+        es: {
+          language: 'es',
+          autoselect: true,
+          default: false,
+          playlists: [
+            {
+              attributes: {
+                'NAME': '1',
+                'BANDWIDTH': 130405,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1,
+                'AUDIO': 'audio',
+                'SUBTITLES': 'subs'
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 60,
+              segments: [],
+              mediaSequence: 1,
+              sidx: {
+                uri: 'http://example.com/audio_es_2c_128k_aac.mp4',
+                resolvedUri: 'http://example.com/audio_es_2c_128k_aac.mp4',
+                byterange: {
+                  length: 224,
+                  offset: 786
+                },
+                map: {
+                  uri: '',
+                  resolvedUri: 'http://example.com/audio_es_2c_128k_aac.mp4',
+                  byterange: {
+                    length: 786,
+                    offset: 0
+                  }
+                },
+                duration: 60,
+                timeline: 0,
+                number: 0
+              }
+            }
+          ],
+          uri: ''
+        }
+      }
+    },
+    'VIDEO': {},
+    'CLOSED-CAPTIONS': {},
+    'SUBTITLES': {}
+  },
+  uri: '',
+  duration: 60,
+  playlists: []
+};

--- a/test/manifests/audio-only.mpd
+++ b/test/manifests/audio-only.mpd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generated with https://github.com/google/shaka-packager version v2.4.1-c731217-release-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT60S">
+  <Period id="0">
+    <AdaptationSet id="0" contentType="audio" lang="en" subsegmentAlignment="true">
+      <Representation id="0" bandwidth="130803" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="48000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>http://example.com/audio_en_2c_128k_aac.mp4</BaseURL>
+        <SegmentBase indexRange="786-1009" timescale="48000">
+          <Initialization range="0-785"/>
+        </SegmentBase>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" contentType="audio" lang="es" subsegmentAlignment="true">
+      <Representation id="1" bandwidth="130405" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="48000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>http://example.com/audio_es_2c_128k_aac.mp4</BaseURL>
+        <SegmentBase indexRange="786-1009" timescale="48000">
+          <Initialization range="0-785"/>
+        </SegmentBase>
+      </Representation>
+    </AdaptationSet>
+
+  </Period>
+</MPD>

--- a/test/manifests/maat_vtt_segmentTemplate.js
+++ b/test/manifests/maat_vtt_segmentTemplate.js
@@ -1,347 +1,518 @@
 export const parsedManifest = {
   allowCache: true,
   discontinuityStarts: [],
-  duration: 6,
+  segments: [],
   endList: true,
   mediaGroups: {
-    AUDIO: {
+    'AUDIO': {
       audio: {
-        ['en (main)']: {
+        'en (main)': {
+          language: 'en',
           autoselect: true,
           default: true,
-          language: 'en',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 125000,
-              CODECS: 'mp4a.40.2',
-              NAME: '125000',
-              ['PROGRAM-ID']: 1
-            },
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          playlists: [
+            {
+              attributes: {
+                'NAME': '63000',
+                'BANDWIDTH': 63000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '63000/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/0.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: '63000/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/1.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '63000/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/2.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '63000/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/63000/3.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             },
-            endList: true,
-            mediaSequence: 0,
-            targetDuration: 1.984,
-            resolvedUri: '',
-            segments: [{
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
+            {
+              attributes: {
+                'NAME': '125000',
+                'BANDWIDTH': 125000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
               },
-              resolvedUri: 'https://www.example.com/125000/0.m4f',
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: '125000/0.m4f',
-              number: 0
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/1.m4f',
-              timeline: 0,
-              uri: '125000/1.m4f',
-              number: 1
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/2.m4f',
-              timeline: 0,
-              uri: '125000/2.m4f',
-              number: 2
-            }, {
-              duration: 0.04800000000000004,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/3.m4f',
-              timeline: 0,
-              uri: '125000/3.m4f',
-              number: 3
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '125000/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/0.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: '125000/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/1.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '125000/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/2.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '125000/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/125000/3.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            }
+          ],
           uri: ''
         },
-        ['es']: {
+        'es': {
+          language: 'es',
           autoselect: true,
           default: false,
-          language: 'es',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 125000,
-              CODECS: 'mp4a.40.2',
-              NAME: '125000',
-              ['PROGRAM-ID']: 1
-            },
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          playlists: [
+            {
+              attributes: {
+                'NAME': '63000',
+                'BANDWIDTH': 63000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '63000/es/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/0.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: '63000/es/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/1.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '63000/es/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/2.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '63000/es/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/63000/es/3.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             },
-            endList: true,
-            targetDuration: 1.984,
-            mediaSequence: 0,
-            resolvedUri: '',
-            segments: [{
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
+            {
+              attributes: {
+                'NAME': '125000',
+                'BANDWIDTH': 125000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
               },
-              resolvedUri: 'https://www.example.com/125000/es/0.m4f',
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: '125000/es/0.m4f',
-              number: 0
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/1.m4f',
-              timeline: 0,
-              uri: '125000/es/1.m4f',
-              number: 1
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/2.m4f',
-              timeline: 0,
-              uri: '125000/es/2.m4f',
-              number: 2
-            }, {
-              duration: 0.04800000000000004,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/3.m4f',
-              timeline: 0,
-              uri: '125000/es/3.m4f',
-              number: 3
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '125000/es/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/0.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: '125000/es/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/1.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '125000/es/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/2.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '125000/es/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/125000/es/3.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            }
+          ],
           uri: ''
         }
       }
     },
-    ['CLOSED-CAPTIONS']: {},
-    SUBTITLES: {
+    'VIDEO': {},
+    'CLOSED-CAPTIONS': {},
+    'SUBTITLES': {
       subs: {
         en: {
-          autoselect: false,
-          default: false,
           language: 'en',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 256,
-              NAME: 'en',
-              ['PROGRAM-ID']: 1
-            },
-            mediaSequence: 0,
-            endList: true,
-            targetDuration: 6,
-            resolvedUri: 'https://example.com/en.vtt',
-            segments: [{
-              duration: 6,
-              resolvedUri: 'https://example.com/en.vtt',
+          default: false,
+          autoselect: false,
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'en',
+                'BANDWIDTH': 256,
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: 'https://example.com/en.vtt',
-              number: 0
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: 'https://example.com/en.vtt',
+              targetDuration: 6,
+              segments: [
+                {
+                  uri: 'https://example.com/en.vtt',
+                  timeline: 0,
+                  resolvedUri: 'https://example.com/en.vtt',
+                  duration: 6,
+                  number: 0
+                }
+              ],
+              mediaSequence: 0
+            }
+          ],
           uri: ''
         },
         es: {
-          autoselect: false,
-          default: false,
           language: 'es',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 256,
-              NAME: 'es',
-              ['PROGRAM-ID']: 1
-            },
-            endList: true,
-            targetDuration: 6,
-            mediaSequence: 0,
-            resolvedUri: 'https://example.com/es.vtt',
-            segments: [{
-              duration: 6,
-              resolvedUri: 'https://example.com/es.vtt',
+          default: false,
+          autoselect: false,
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'es',
+                'BANDWIDTH': 256,
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: 'https://example.com/es.vtt',
-              number: 0
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: 'https://example.com/es.vtt',
+              targetDuration: 6,
+              segments: [
+                {
+                  uri: 'https://example.com/es.vtt',
+                  timeline: 0,
+                  resolvedUri: 'https://example.com/es.vtt',
+                  duration: 6,
+                  number: 0
+                }
+              ],
+              mediaSequence: 0
+            }
+          ],
           uri: ''
         }
       }
-    },
-    VIDEO: {}
+    }
   },
-  playlists: [{
-    attributes: {
-      AUDIO: 'audio',
-      SUBTITLES: 'subs',
-      BANDWIDTH: 449000,
-      CODECS: 'avc1.420015',
-      NAME: '482',
-      ['PROGRAM-ID']: 1,
-      RESOLUTION: {
-        height: 270,
-        width: 482
-      }
-    },
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+  uri: '',
+  duration: 6,
+  playlists: [
+    {
+      attributes: {
+        'NAME': '482',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 482,
+          height: 270
         },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    },
-    endList: true,
-    targetDuration: 1.9185833333333333,
-    mediaSequence: 0,
-    resolvedUri: '',
-    segments: [{
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
+        'CODECS': 'avc1.420015',
+        'BANDWIDTH': 449000,
+        'PROGRAM-ID': 1
       },
-      resolvedUri: 'https://www.example.com/482/0.m4f',
+      uri: '',
+      endList: true,
       timeline: 0,
-      uri: '482/0.m4f',
-      number: 0
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/1.m4f',
-      timeline: 0,
-      uri: '482/1.m4f',
-      number: 1
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/2.m4f',
-      timeline: 0,
-      uri: '482/2.m4f',
-      number: 2
-    }, {
-      duration: 0.24425000000000008,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/3.m4f',
-      timeline: 0,
-      uri: '482/3.m4f',
-      number: 3
-    }],
-    timeline: 0,
-    uri: ''
-  }, {
-    attributes: {
-      AUDIO: 'audio',
-      SUBTITLES: 'subs',
-      BANDWIDTH: 3971000,
-      CODECS: 'avc1.64001e',
-      NAME: '720',
-      ['PROGRAM-ID']: 1,
-      RESOLUTION: {
-        height: 404,
-        width: 720
-      }
-    },
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+      resolvedUri: '',
+      targetDuration: 1.9185833333333333,
+      segments: [
+        {
+          uri: '482/0.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/0.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 0
         },
-        pssh: new Uint8Array([181, 235, 45])
+        {
+          uri: '482/1.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/1.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: '482/2.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/2.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: '482/3.m4f',
+          timeline: 0,
+          duration: 0.24425000000000008,
+          resolvedUri: 'https://www.example.com/482/3.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 3
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
       }
     },
-    endList: true,
-    targetDuration: 1.9185833333333333,
-    mediaSequence: 0,
-    resolvedUri: '',
-    segments: [{
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
+    {
+      attributes: {
+        'NAME': '720',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 720,
+          height: 404
+        },
+        'CODECS': 'avc1.64001e',
+        'BANDWIDTH': 3971000,
+        'PROGRAM-ID': 1
       },
-      resolvedUri: 'https://www.example.com/720/0.m4f',
+      uri: '',
+      endList: true,
       timeline: 0,
-      uri: '720/0.m4f',
-      number: 0
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/1.m4f',
-      timeline: 0,
-      uri: '720/1.m4f',
-      number: 1
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/2.m4f',
-      timeline: 0,
-      uri: '720/2.m4f',
-      number: 2
-    }, {
-      duration: 0.24425000000000008,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/3.m4f',
-      timeline: 0,
-      uri: '720/3.m4f',
-      number: 3
-    }],
-    timeline: 0,
-    uri: ''
-  }],
-  segments: [],
-  uri: ''
+      resolvedUri: '',
+      targetDuration: 1.9185833333333333,
+      segments: [
+        {
+          uri: '720/0.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/0.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: '720/1.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/1.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: '720/2.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/2.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: '720/3.m4f',
+          timeline: 0,
+          duration: 0.24425000000000008,
+          resolvedUri: 'https://www.example.com/720/3.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 3
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
+    }
+  ]
 };

--- a/test/manifests/multiperiod-dynamic.js
+++ b/test/manifests/multiperiod-dynamic.js
@@ -10,233 +10,504 @@ export const parsedManifest = {
           language: 'en',
           autoselect: true,
           default: true,
-          playlists: [{
-            attributes: {
-              'NAME': 'default_audio128_2',
-              'BANDWIDTH': 123000,
-              'CODECS': 'mp4a.40.2',
-              'PROGRAM-ID': 1
-            },
-            uri: '',
-            endList: false,
-            timeline: 0,
-            resolvedUri: '',
-            targetDuration: 2,
-            segments: [{
-              uri: 'https://example.com/default_audio128_2/segment0.m4f',
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'default_audio128_2',
+                'BANDWIDTH': 123000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: false,
               timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment0.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 0
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment1.m4f',
-              timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment1.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 1
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment2.m4f',
-              timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment2.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 2
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment3.m4f',
-              timeline: 1,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment3.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 3,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment4.m4f',
-              timeline: 1,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment4.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 4
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment5.m4f',
-              timeline: 1,
-              duration: 0.8591383219954648,
-              resolvedUri: 'https://example.com/default_audio128_2/segment5.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 5
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment6.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment6.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 6,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment7.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment7.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 7
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment8.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment8.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 8
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment9.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment9.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 9
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment10.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment10.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 10
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment11.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment11.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 11
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment12.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment12.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 12
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment13.m4f',
-              timeline: 2,
-              duration: 0.023219954648526078,
-              resolvedUri: 'https://example.com/default_audio128_2/segment13.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 13
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment14.m4f',
-              timeline: 3,
-              duration: 1.1609977324263039,
-              resolvedUri: 'https://example.com/default_audio128_2/segment14.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init3.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
-              },
-              number: 14,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment15.m4f',
-              timeline: 3,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment15.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init3.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
-              },
-              number: 15
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment16.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment16.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 16,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment17.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment17.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 17
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment18.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment18.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 18
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment19.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment19.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 19
-            }],
-            mediaSequence: 0,
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+              resolvedUri: '',
+              targetDuration: 2,
+              segments: [
+                {
+                  uri: 'https://example.com/default_audio128_2/segment0.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment0.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: 'https://example.com/default_audio128_2/segment1.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment1.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment2.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment2.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment3.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment3.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 3,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment4.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment4.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 4
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment5.m4f',
+                  timeline: 1,
+                  duration: 0.8591383219954648,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment5.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 5
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment6.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment6.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 6,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment7.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment7.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 7
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment8.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment8.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 8
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment9.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment9.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 9
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment10.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment10.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 10
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment11.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment11.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 11
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment12.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment12.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 12
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment13.m4f',
+                  timeline: 2,
+                  duration: 0.023219954648526078,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment13.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 13
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment14.m4f',
+                  timeline: 3,
+                  duration: 1.1609977324263039,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment14.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
+                  },
+                  number: 14,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment15.m4f',
+                  timeline: 3,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment15.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
+                  },
+                  number: 15
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment16.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment16.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 16,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment17.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment17.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 17
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment18.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment18.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 18
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment19.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment19.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 19
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            },
+            {
+              attributes: {
+                'NAME': 'default_audio96_2',
+                'BANDWIDTH': 93000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: false,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 2,
+              segments: [
+                {
+                  uri: 'https://example.com/default_audio96_2/segment0.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment0.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment1.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment1.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment2.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment2.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment3.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment3.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 3,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment4.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment4.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 4
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment5.m4f',
+                  timeline: 1,
+                  duration: 0.8591383219954648,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment5.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 5
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment6.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment6.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 6,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment7.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment7.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 7
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment8.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment8.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 8
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment9.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment9.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 9
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment10.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment10.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 10
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment11.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment11.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 11
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment12.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment12.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 12
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment13.m4f',
+                  timeline: 2,
+                  duration: 0.023219954648526078,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment13.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 13
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment14.m4f',
+                  timeline: 3,
+                  duration: 1.1609977324263039,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment14.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init3.m4f'
+                  },
+                  number: 14,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment15.m4f',
+                  timeline: 3,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment15.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init3.m4f'
+                  },
+                  number: 15
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment16.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment16.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 16,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment17.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment17.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 17
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment18.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment18.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 18
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment19.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment19.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 19
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             }
-          }],
+          ],
           uri: ''
         }
       }
@@ -247,706 +518,769 @@ export const parsedManifest = {
   },
   uri: '',
   duration: 36.269,
-  playlists: [{
-    attributes: {
-      'NAME': 'default_video2000_0_1280x720',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 1280,
-        height: 720
+  playlists: [
+    {
+      attributes: {
+        'NAME': 'default_video2000_0_1280x720',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 1280,
+          height: 720
+        },
+        'CODECS': 'avc1.4d001f',
+        'BANDWIDTH': 2008000,
+        'PROGRAM-ID': 1
       },
-      'CODECS': 'avc1.4d001f',
-      'BANDWIDTH': 2008E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: false,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+      uri: '',
+      endList: false,
       timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
     },
     {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+      attributes: {
+        'NAME': 'default_video1200_1_960x540',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 960,
+          height: 540
         },
-        pssh: new Uint8Array([181, 235, 45])
+        'CODECS': 'avc1.4d001f',
+        'BANDWIDTH': 1195000,
+        'PROGRAM-ID': 1
+      },
+      uri: '',
+      endList: false,
+      timeline: 0,
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
+    },
+    {
+      attributes: {
+        'NAME': 'default_video900_1_640x360',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 640,
+          height: 360
+        },
+        'CODECS': 'avc1.4d001e',
+        'BANDWIDTH': 884000,
+        'PROGRAM-ID': 1
+      },
+      uri: '',
+      endList: false,
+      timeline: 0,
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
       }
     }
-  }, {
-    attributes: {
-      'NAME': 'default_video1200_1_960x540',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 960,
-        height: 540
-      },
-      'CODECS': 'avc1.4d001f',
-      'BANDWIDTH': 1195E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: false,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
-        },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    }
-  }, {
-    attributes: {
-      'NAME': 'default_video900_1_640x360',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 640,
-        height: 360
-      },
-      'CODECS': 'avc1.4d001e',
-      'BANDWIDTH': 884E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: false,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
-        },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    }
-  }],
+  ],
   suggestedPresentationDelay: 18
 };

--- a/test/manifests/multiperiod.js
+++ b/test/manifests/multiperiod.js
@@ -10,233 +10,504 @@ export const parsedManifest = {
           language: 'en',
           autoselect: true,
           default: true,
-          playlists: [{
-            attributes: {
-              'NAME': 'default_audio128_2',
-              'BANDWIDTH': 123000,
-              'CODECS': 'mp4a.40.2',
-              'PROGRAM-ID': 1
-            },
-            uri: '',
-            endList: true,
-            timeline: 0,
-            resolvedUri: '',
-            targetDuration: 2,
-            segments: [{
-              uri: 'https://example.com/default_audio128_2/segment0.m4f',
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'default_audio128_2',
+                'BANDWIDTH': 123000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
               timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment0.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 0
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment1.m4f',
-              timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment1.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 1
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment2.m4f',
-              timeline: 0,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment2.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init0.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
-              },
-              number: 2
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment3.m4f',
-              timeline: 1,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment3.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 3,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment4.m4f',
-              timeline: 1,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment4.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 4
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment5.m4f',
-              timeline: 1,
-              duration: 0.8591383219954648,
-              resolvedUri: 'https://example.com/default_audio128_2/segment5.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init1.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
-              },
-              number: 5
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment6.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment6.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 6,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment7.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment7.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 7
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment8.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment8.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 8
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment9.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment9.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 9
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment10.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment10.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 10
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment11.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment11.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 11
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment12.m4f',
-              timeline: 2,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment12.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 12
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment13.m4f',
-              timeline: 2,
-              duration: 0.023219954648526078,
-              resolvedUri: 'https://example.com/default_audio128_2/segment13.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init2.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
-              },
-              number: 13
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment14.m4f',
-              timeline: 3,
-              duration: 1.1609977324263039,
-              resolvedUri: 'https://example.com/default_audio128_2/segment14.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init3.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
-              },
-              number: 14,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment15.m4f',
-              timeline: 3,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment15.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/init3.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
-              },
-              number: 15
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment16.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment16.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 16,
-              discontinuity: true
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment17.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment17.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 17
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment18.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment18.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 18
-            }, {
-              uri: 'https://example.com/default_audio128_2/segment19.m4f',
-              timeline: 4,
-              duration: 1.9969160997732427,
-              resolvedUri: 'https://example.com/default_audio128_2/segment19.m4f',
-              map: {
-                uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
-                resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
-              },
-              number: 19
-            }],
-            mediaSequence: 0,
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+              resolvedUri: '',
+              targetDuration: 2,
+              segments: [
+                {
+                  uri: 'https://example.com/default_audio128_2/segment0.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment0.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: 'https://example.com/default_audio128_2/segment1.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment1.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment2.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment2.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init0.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment3.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment3.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 3,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment4.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment4.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 4
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment5.m4f',
+                  timeline: 1,
+                  duration: 0.8591383219954648,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment5.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init1.m4f'
+                  },
+                  number: 5
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment6.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment6.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 6,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment7.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment7.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 7
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment8.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment8.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 8
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment9.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment9.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 9
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment10.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment10.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 10
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment11.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment11.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 11
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment12.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment12.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 12
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment13.m4f',
+                  timeline: 2,
+                  duration: 0.023219954648526078,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment13.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init2.m4f'
+                  },
+                  number: 13
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment14.m4f',
+                  timeline: 3,
+                  duration: 1.1609977324263039,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment14.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
+                  },
+                  number: 14,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment15.m4f',
+                  timeline: 3,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment15.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/init3.m4f'
+                  },
+                  number: 15
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment16.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment16.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 16,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment17.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment17.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 17
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment18.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment18.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 18
+                },
+                {
+                  uri: 'https://example.com/default_audio128_2/segment19.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio128_2/segment19.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio128_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio128_2/segment$Number$.m4f'
+                  },
+                  number: 19
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            },
+            {
+              attributes: {
+                'NAME': 'default_audio96_2',
+                'BANDWIDTH': 93000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 2,
+              segments: [
+                {
+                  uri: 'https://example.com/default_audio96_2/segment0.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment0.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment1.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment1.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment2.m4f',
+                  timeline: 0,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment2.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init0.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init0.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment3.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment3.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 3,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment4.m4f',
+                  timeline: 1,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment4.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 4
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment5.m4f',
+                  timeline: 1,
+                  duration: 0.8591383219954648,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment5.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init1.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init1.m4f'
+                  },
+                  number: 5
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment6.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment6.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 6,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment7.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment7.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 7
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment8.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment8.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 8
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment9.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment9.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 9
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment10.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment10.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 10
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment11.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment11.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 11
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment12.m4f',
+                  timeline: 2,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment12.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 12
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment13.m4f',
+                  timeline: 2,
+                  duration: 0.023219954648526078,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment13.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init2.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init2.m4f'
+                  },
+                  number: 13
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment14.m4f',
+                  timeline: 3,
+                  duration: 1.1609977324263039,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment14.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init3.m4f'
+                  },
+                  number: 14,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment15.m4f',
+                  timeline: 3,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment15.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/init3.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/init3.m4f'
+                  },
+                  number: 15
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment16.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment16.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 16,
+                  discontinuity: true
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment17.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment17.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 17
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment18.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment18.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 18
+                },
+                {
+                  uri: 'https://example.com/default_audio96_2/segment19.m4f',
+                  timeline: 4,
+                  duration: 1.9969160997732427,
+                  resolvedUri: 'https://example.com/default_audio96_2/segment19.m4f',
+                  map: {
+                    uri: 'https://example.com/default_audio96_2/segment$Number$.m4f',
+                    resolvedUri: 'https://example.com/default_audio96_2/segment$Number$.m4f'
+                  },
+                  number: 19
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             }
-          }],
+          ],
           uri: ''
         }
       }
@@ -247,705 +518,768 @@ export const parsedManifest = {
   },
   uri: '',
   duration: 36.269,
-  playlists: [{
-    attributes: {
-      'NAME': 'default_video2000_0_1280x720',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 1280,
-        height: 720
+  playlists: [
+    {
+      attributes: {
+        'NAME': 'default_video2000_0_1280x720',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 1280,
+          height: 720
+        },
+        'CODECS': 'avc1.4d001f',
+        'BANDWIDTH': 2008000,
+        'PROGRAM-ID': 1
       },
-      'CODECS': 'avc1.4d001f',
-      'BANDWIDTH': 2008E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: true,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+      uri: '',
+      endList: true,
       timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init0.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init1.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
     },
     {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init2.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/init3.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video2000_0_1280x720/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+      attributes: {
+        'NAME': 'default_video1200_1_960x540',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 960,
+          height: 540
         },
-        pssh: new Uint8Array([181, 235, 45])
+        'CODECS': 'avc1.4d001f',
+        'BANDWIDTH': 1195000,
+        'PROGRAM-ID': 1
+      },
+      uri: '',
+      endList: true,
+      timeline: 0,
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
+    },
+    {
+      attributes: {
+        'NAME': 'default_video900_1_640x360',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 640,
+          height: 360
+        },
+        'CODECS': 'avc1.4d001e',
+        'BANDWIDTH': 884000,
+        'PROGRAM-ID': 1
+      },
+      uri: '',
+      endList: true,
+      timeline: 0,
+      resolvedUri: '',
+      targetDuration: 3,
+      segments: [
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
+          timeline: 0,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
+          timeline: 0,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 3,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
+          timeline: 1,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 4
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
+          timeline: 1,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
+          },
+          number: 5
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 6,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 7
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 8
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 9
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 10
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
+          timeline: 2,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 11
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
+          timeline: 2,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
+          },
+          number: 12
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
+          timeline: 3,
+          duration: 0.9676333333333333,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 13,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
+          timeline: 3,
+          duration: 1.9352666666666667,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 14
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
+          timeline: 3,
+          duration: 0.26693333333333336,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
+          },
+          number: 15
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 16,
+          discontinuity: true
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 17
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
+          timeline: 4,
+          duration: 2.002,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 18
+        },
+        {
+          uri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
+          timeline: 4,
+          duration: 1.9686333333333332,
+          resolvedUri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
+          map: {
+            uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
+            resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
+          },
+          number: 19
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
       }
     }
-  }, {
-    attributes: {
-      'NAME': 'default_video1200_1_960x540',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 960,
-        height: 540
-      },
-      'CODECS': 'avc1.4d001f',
-      'BANDWIDTH': 1195E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: true,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init0.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init1.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init2.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/init3.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video1200_1_960x540/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video1200_1_960x540/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
-        },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    }
-  }, {
-    attributes: {
-      'NAME': 'default_video900_1_640x360',
-      'AUDIO': 'audio',
-      'SUBTITLES': 'subs',
-      'RESOLUTION': {
-        width: 640,
-        height: 360
-      },
-      'CODECS': 'avc1.4d001e',
-      'BANDWIDTH': 884E3,
-      'PROGRAM-ID': 1
-    },
-    uri: '',
-    endList: true,
-    timeline: 0,
-    resolvedUri: '',
-    targetDuration: 3,
-    segments: [{
-      uri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment0.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 0
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
-      timeline: 0,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment1.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 1
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
-      timeline: 0,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment2.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init0.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init0.m4f'
-      },
-      number: 2
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment3.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 3,
-      discontinuity: true
-    },
-    {
-      uri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
-      timeline: 1,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment4.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 4
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
-      timeline: 1,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment5.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init1.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init1.m4f'
-      },
-      number: 5
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment6.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 6,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment7.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 7
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment8.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 8
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment9.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 9
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment10.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 10
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
-      timeline: 2,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment11.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 11
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
-      timeline: 2,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment12.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init2.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init2.m4f'
-      },
-      number: 12
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
-      timeline: 3,
-      duration: 0.9676333333333333,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment13.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 13,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
-      timeline: 3,
-      duration: 1.9352666666666667,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment14.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 14
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
-      timeline: 3,
-      duration: 0.26693333333333336,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment15.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/init3.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/init3.m4f'
-      },
-      number: 15
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment16.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 16,
-      discontinuity: true
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment17.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 17
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
-      timeline: 4,
-      duration: 2.002,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment18.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 18
-    }, {
-      uri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
-      timeline: 4,
-      duration: 1.9686333333333332,
-      resolvedUri: 'https://example.com/default_video900_1_640x360/segment19.m4f',
-      map: {
-        uri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f',
-        resolvedUri: 'https://example.com/default_video900_1_640x360/segment$Number$.m4f'
-      },
-      number: 19
-    }],
-    mediaSequence: 0,
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
-        },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    }
-  }]
+  ]
 };

--- a/test/manifests/vtt_codecs.js
+++ b/test/manifests/vtt_codecs.js
@@ -1,348 +1,519 @@
 export const parsedManifest = {
   allowCache: true,
   discontinuityStarts: [],
-  duration: 6,
+  segments: [],
   endList: true,
   mediaGroups: {
-    AUDIO: {
+    'AUDIO': {
       audio: {
-        ['en (main)']: {
+        'en (main)': {
+          language: 'en',
           autoselect: true,
           default: true,
-          language: 'en',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 125000,
-              CODECS: 'mp4a.40.2',
-              NAME: '125000',
-              ['PROGRAM-ID']: 1
-            },
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          playlists: [
+            {
+              attributes: {
+                'NAME': '63000',
+                'BANDWIDTH': 63000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '63000/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/0.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: '63000/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/1.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '63000/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/2.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '63000/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/63000/3.m4f',
+                  map: {
+                    uri: '63000/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             },
-            endList: true,
-            mediaSequence: 0,
-            targetDuration: 1.984,
-            resolvedUri: '',
-            segments: [{
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
+            {
+              attributes: {
+                'NAME': '125000',
+                'BANDWIDTH': 125000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
               },
-              resolvedUri: 'https://www.example.com/125000/0.m4f',
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: '125000/0.m4f',
-              number: 0
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/1.m4f',
-              timeline: 0,
-              uri: '125000/1.m4f',
-              number: 1
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/2.m4f',
-              timeline: 0,
-              uri: '125000/2.m4f',
-              number: 2
-            }, {
-              duration: 0.04800000000000004,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/init.m4f',
-                uri: '125000/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/3.m4f',
-              timeline: 0,
-              uri: '125000/3.m4f',
-              number: 3
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '125000/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/0.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: '125000/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/1.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '125000/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/2.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '125000/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/125000/3.m4f',
+                  map: {
+                    uri: '125000/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            }
+          ],
           uri: ''
         },
-        ['es']: {
+        'es': {
+          language: 'es',
           autoselect: true,
           default: false,
-          language: 'es',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 125000,
-              CODECS: 'mp4a.40.2',
-              NAME: '125000',
-              ['PROGRAM-ID']: 1
-            },
-            contentProtection: {
-              'com.widevine.alpha': {
-                attributes: {
-                  schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          playlists: [
+            {
+              attributes: {
+                'NAME': '63000',
+                'BANDWIDTH': 63000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
+              timeline: 0,
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '63000/es/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/0.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 0
                 },
-                pssh: new Uint8Array([181, 235, 45])
+                {
+                  uri: '63000/es/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/1.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '63000/es/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/63000/es/2.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '63000/es/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/63000/es/3.m4f',
+                  map: {
+                    uri: '63000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/63000/es/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
               }
             },
-            endList: true,
-            targetDuration: 1.984,
-            mediaSequence: 0,
-            resolvedUri: '',
-            segments: [{
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
+            {
+              attributes: {
+                'NAME': '125000',
+                'BANDWIDTH': 125000,
+                'CODECS': 'mp4a.40.2',
+                'PROGRAM-ID': 1
               },
-              resolvedUri: 'https://www.example.com/125000/es/0.m4f',
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: '125000/es/0.m4f',
-              number: 0
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/1.m4f',
-              timeline: 0,
-              uri: '125000/es/1.m4f',
-              number: 1
-            }, {
-              duration: 1.984,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/2.m4f',
-              timeline: 0,
-              uri: '125000/es/2.m4f',
-              number: 2
-            }, {
-              duration: 0.04800000000000004,
-              map: {
-                resolvedUri: 'https://www.example.com/125000/es/init.m4f',
-                uri: '125000/es/init.m4f'
-              },
-              resolvedUri: 'https://www.example.com/125000/es/3.m4f',
-              timeline: 0,
-              uri: '125000/es/3.m4f',
-              number: 3
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: '',
+              targetDuration: 1.984,
+              segments: [
+                {
+                  uri: '125000/es/0.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/0.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 0
+                },
+                {
+                  uri: '125000/es/1.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/1.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 1
+                },
+                {
+                  uri: '125000/es/2.m4f',
+                  timeline: 0,
+                  duration: 1.984,
+                  resolvedUri: 'https://www.example.com/125000/es/2.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 2
+                },
+                {
+                  uri: '125000/es/3.m4f',
+                  timeline: 0,
+                  duration: 0.04800000000000004,
+                  resolvedUri: 'https://www.example.com/125000/es/3.m4f',
+                  map: {
+                    uri: '125000/es/init.m4f',
+                    resolvedUri: 'https://www.example.com/125000/es/init.m4f'
+                  },
+                  number: 3
+                }
+              ],
+              mediaSequence: 0,
+              contentProtection: {
+                'com.widevine.alpha': {
+                  attributes: {
+                    schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+                  },
+                  pssh: new Uint8Array([181, 235, 45])
+                }
+              }
+            }
+          ],
           uri: ''
         }
       }
     },
-    ['CLOSED-CAPTIONS']: {},
-    SUBTITLES: {
+    'VIDEO': {},
+    'CLOSED-CAPTIONS': {},
+    'SUBTITLES': {
       subs: {
         en: {
-          autoselect: false,
-          default: false,
           language: 'en',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 256,
-              NAME: 'en',
-              CODECS: 'stpp.ttml.im1t',
-              ['PROGRAM-ID']: 1
-            },
-            mediaSequence: 0,
-            endList: true,
-            targetDuration: 6,
-            resolvedUri: 'https://example.com/en.dash',
-            segments: [{
-              duration: 6,
-              resolvedUri: 'https://example.com/en.dash',
+          default: false,
+          autoselect: false,
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'en',
+                'BANDWIDTH': 256,
+                'PROGRAM-ID': 1,
+                'CODECS': 'stpp.ttml.im1t'
+              },
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: 'https://example.com/en.dash',
-              number: 0
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: 'https://example.com/en.dash',
+              targetDuration: 6,
+              segments: [
+                {
+                  uri: 'https://example.com/en.dash',
+                  timeline: 0,
+                  resolvedUri: 'https://example.com/en.dash',
+                  duration: 6,
+                  number: 0
+                }
+              ],
+              mediaSequence: 0
+            }
+          ],
           uri: ''
         },
         es: {
-          autoselect: false,
-          default: false,
           language: 'es',
-          playlists: [{
-            attributes: {
-              BANDWIDTH: 256,
-              NAME: 'es',
-              ['PROGRAM-ID']: 1
-            },
-            endList: true,
-            targetDuration: 6,
-            mediaSequence: 0,
-            resolvedUri: 'https://example.com/es.vtt',
-            segments: [{
-              duration: 6,
-              resolvedUri: 'https://example.com/es.vtt',
+          default: false,
+          autoselect: false,
+          playlists: [
+            {
+              attributes: {
+                'NAME': 'es',
+                'BANDWIDTH': 256,
+                'PROGRAM-ID': 1
+              },
+              uri: '',
+              endList: true,
               timeline: 0,
-              uri: 'https://example.com/es.vtt',
-              number: 0
-            }],
-            timeline: 0,
-            uri: ''
-          }],
+              resolvedUri: 'https://example.com/es.vtt',
+              targetDuration: 6,
+              segments: [
+                {
+                  uri: 'https://example.com/es.vtt',
+                  timeline: 0,
+                  resolvedUri: 'https://example.com/es.vtt',
+                  duration: 6,
+                  number: 0
+                }
+              ],
+              mediaSequence: 0
+            }
+          ],
           uri: ''
         }
       }
-    },
-    VIDEO: {}
+    }
   },
-  playlists: [{
-    attributes: {
-      AUDIO: 'audio',
-      SUBTITLES: 'subs',
-      BANDWIDTH: 449000,
-      CODECS: 'avc1.420015',
-      NAME: '482',
-      ['PROGRAM-ID']: 1,
-      RESOLUTION: {
-        height: 270,
-        width: 482
-      }
-    },
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+  uri: '',
+  duration: 6,
+  playlists: [
+    {
+      attributes: {
+        'NAME': '482',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 482,
+          height: 270
         },
-        pssh: new Uint8Array([181, 235, 45])
-      }
-    },
-    endList: true,
-    targetDuration: 1.9185833333333333,
-    mediaSequence: 0,
-    resolvedUri: '',
-    segments: [{
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
+        'CODECS': 'avc1.420015',
+        'BANDWIDTH': 449000,
+        'PROGRAM-ID': 1
       },
-      resolvedUri: 'https://www.example.com/482/0.m4f',
+      uri: '',
+      endList: true,
       timeline: 0,
-      uri: '482/0.m4f',
-      number: 0
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/1.m4f',
-      timeline: 0,
-      uri: '482/1.m4f',
-      number: 1
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/2.m4f',
-      timeline: 0,
-      uri: '482/2.m4f',
-      number: 2
-    }, {
-      duration: 0.24425000000000008,
-      map: {
-        resolvedUri: 'https://www.example.com/482/init.m4f',
-        uri: '482/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/482/3.m4f',
-      timeline: 0,
-      uri: '482/3.m4f',
-      number: 3
-    }],
-    timeline: 0,
-    uri: ''
-  }, {
-    attributes: {
-      AUDIO: 'audio',
-      SUBTITLES: 'subs',
-      BANDWIDTH: 3971000,
-      CODECS: 'avc1.64001e',
-      NAME: '720',
-      ['PROGRAM-ID']: 1,
-      RESOLUTION: {
-        height: 404,
-        width: 720
-      }
-    },
-    contentProtection: {
-      'com.widevine.alpha': {
-        attributes: {
-          schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+      resolvedUri: '',
+      targetDuration: 1.9185833333333333,
+      segments: [
+        {
+          uri: '482/0.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/0.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 0
         },
-        pssh: new Uint8Array([181, 235, 45])
+        {
+          uri: '482/1.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/1.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: '482/2.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/482/2.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: '482/3.m4f',
+          timeline: 0,
+          duration: 0.24425000000000008,
+          resolvedUri: 'https://www.example.com/482/3.m4f',
+          map: {
+            uri: '482/init.m4f',
+            resolvedUri: 'https://www.example.com/482/init.m4f'
+          },
+          number: 3
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
       }
     },
-    endList: true,
-    targetDuration: 1.9185833333333333,
-    mediaSequence: 0,
-    resolvedUri: '',
-    segments: [{
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
+    {
+      attributes: {
+        'NAME': '720',
+        'AUDIO': 'audio',
+        'SUBTITLES': 'subs',
+        'RESOLUTION': {
+          width: 720,
+          height: 404
+        },
+        'CODECS': 'avc1.64001e',
+        'BANDWIDTH': 3971000,
+        'PROGRAM-ID': 1
       },
-      resolvedUri: 'https://www.example.com/720/0.m4f',
+      uri: '',
+      endList: true,
       timeline: 0,
-      uri: '720/0.m4f',
-      number: 0
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/1.m4f',
-      timeline: 0,
-      uri: '720/1.m4f',
-      number: 1
-    }, {
-      duration: 1.9185833333333333,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/2.m4f',
-      timeline: 0,
-      uri: '720/2.m4f',
-      number: 2
-    }, {
-      duration: 0.24425000000000008,
-      map: {
-        resolvedUri: 'https://www.example.com/720/init.m4f',
-        uri: '720/init.m4f'
-      },
-      resolvedUri: 'https://www.example.com/720/3.m4f',
-      timeline: 0,
-      uri: '720/3.m4f',
-      number: 3
-    }],
-    timeline: 0,
-    uri: ''
-  }],
-  segments: [],
-  uri: ''
+      resolvedUri: '',
+      targetDuration: 1.9185833333333333,
+      segments: [
+        {
+          uri: '720/0.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/0.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 0
+        },
+        {
+          uri: '720/1.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/1.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 1
+        },
+        {
+          uri: '720/2.m4f',
+          timeline: 0,
+          duration: 1.9185833333333333,
+          resolvedUri: 'https://www.example.com/720/2.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 2
+        },
+        {
+          uri: '720/3.m4f',
+          timeline: 0,
+          duration: 0.24425000000000008,
+          resolvedUri: 'https://www.example.com/720/3.m4f',
+          map: {
+            uri: '720/init.m4f',
+            resolvedUri: 'https://www.example.com/720/init.m4f'
+          },
+          number: 3
+        }
+      ],
+      mediaSequence: 0,
+      contentProtection: {
+        'com.widevine.alpha': {
+          attributes: {
+            schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed'
+          },
+          pssh: new Uint8Array([181, 235, 45])
+        }
+      }
+    }
+  ]
 };

--- a/test/segment/segmentBase.test.js
+++ b/test/segment/segmentBase.test.js
@@ -1,7 +1,7 @@
 import QUnit from 'qunit';
 import {
   segmentsFromBase,
-  addSegmentsToPlaylist
+  addSidxSegmentsToPlaylist
 } from '../../src/segment/segmentBase';
 import errors from '../../src/errors';
 
@@ -151,7 +151,7 @@ QUnit.test('errors if no baseUrl exists', function(assert) {
   assert.throws(() => segmentsFromBase({}), new Error(errors.NO_BASE_URL));
 });
 
-QUnit.module('segmentBase - addSegmentsToPlaylist');
+QUnit.module('segmentBase - addSidxSegmentsToPlaylist');
 
 QUnit.test('generates playlist from sidx references', function(assert) {
   const baseUrl = 'http://www.example.com/i.fmp4';
@@ -181,7 +181,7 @@ QUnit.test('generates playlist from sidx references', function(assert) {
     }]
   };
 
-  assert.deepEqual(addSegmentsToPlaylist(playlist, sidx, baseUrl).segments, [{
+  assert.deepEqual(addSidxSegmentsToPlaylist(playlist, sidx, baseUrl).segments, [{
     map: {
       byterange: {
         offset: 0,

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -1,4 +1,4 @@
-import { toM3u8 } from '../src/toM3u8';
+import { toM3u8, generateSidxKey } from '../src/toM3u8';
 import QUnit from 'qunit';
 
 QUnit.module('toM3u8');
@@ -746,3 +746,22 @@ QUnit.test('playlists with label', function(assert) {
 
   assert.ok(label in output.mediaGroups.AUDIO.audio, 'label exists');
 });
+
+QUnit.module('generateSidxKey');
+
+QUnit.test('generates correct key', function(assert) {
+  const sidxInfo = {
+    byterange: {
+      offset: 1,
+      length: 5
+    },
+    uri: 'uri'
+  };
+
+  assert.strictEqual(
+    generateSidxKey(sidxInfo),
+    'uri-1-5',
+    'the key byterange should have a inclusive end'
+  );
+});
+

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -85,6 +85,21 @@ QUnit.test('playlists', function(assert) {
               timeline: 1,
               uri: '',
               targetDuration: 0
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
+                CODECS: 'foo;bar',
+                NAME: '2',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 1,
+              endList: true,
+              resolvedUri: '',
+              segments: [],
+              timeline: 1,
+              uri: '',
+              targetDuration: 0
+
             }],
             uri: ''
           }
@@ -100,6 +115,25 @@ QUnit.test('playlists', function(assert) {
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,
+                NAME: '1',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 0,
+              targetDuration: 100,
+              endList: true,
+              resolvedUri: 'https://www.example.com/vtt',
+              segments: [{
+                duration: 100,
+                resolvedUri: 'https://www.example.com/vtt',
+                timeline: 1,
+                uri: 'https://www.example.com/vtt',
+                number: 0
+              }],
+              timeline: 1,
+              uri: ''
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
                 NAME: '1',
                 ['PROGRAM-ID']: 1
               },
@@ -282,7 +316,7 @@ QUnit.test('playlists with segments', function(assert) {
     attributes: {
       sourceDuration: 100,
       duration: 2,
-      id: '1',
+      id: '2',
       bandwidth: 10000,
       periodIndex: 1,
       mimeType: 'text/vtt',
@@ -357,6 +391,40 @@ QUnit.test('playlists with segments', function(assert) {
               }],
               timeline: 1,
               uri: ''
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
+                CODECS: 'foo;bar',
+                NAME: '2',
+                ['PROGRAM-ID']: 1
+              },
+              targetDuration: 2,
+              mediaSequence: 1,
+              endList: true,
+              resolvedUri: '',
+              segments: [{
+                uri: '',
+                timeline: 1,
+                duration: 2,
+                resolvedUri: '',
+                map: {
+                  uri: '',
+                  resolvedUri: ''
+                },
+                number: 1
+              }, {
+                uri: '',
+                timeline: 1,
+                duration: 2,
+                resolvedUri: '',
+                map: {
+                  uri: '',
+                  resolvedUri: ''
+                },
+                number: 2
+              }],
+              timeline: 1,
+              uri: ''
             }],
             uri: ''
           }
@@ -373,6 +441,39 @@ QUnit.test('playlists with segments', function(assert) {
               attributes: {
                 BANDWIDTH: 20000,
                 NAME: '1',
+                ['PROGRAM-ID']: 1
+              },
+              endList: true,
+              targetDuration: 2,
+              mediaSequence: 1,
+              resolvedUri: 'https://www.example.com/vtt',
+              segments: [{
+                uri: '',
+                timeline: 1,
+                duration: 2,
+                resolvedUri: '',
+                map: {
+                  uri: '',
+                  resolvedUri: ''
+                },
+                number: 1
+              }, {
+                uri: '',
+                timeline: 1,
+                duration: 2,
+                resolvedUri: '',
+                map: {
+                  uri: '',
+                  resolvedUri: ''
+                },
+                number: 2
+              }],
+              timeline: 1,
+              uri: ''
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
+                NAME: '2',
                 ['PROGRAM-ID']: 1
               },
               endList: true,


### PR DESCRIPTION
Currently we drop multiple playlists for the same group, when we should allow multiple renditions for the same group. This allows that to happen.

Fixes: #93 
Fixes: #105 
Fixes: #77