### PR TITLE
feat: caption services metadata support

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             console.log('Original ->');
             console.log(body);
 
-            var parsedMpd = mpdParser.parse(body, url.value);
+            var parsedMpd = mpdParser.parse(body, {});
             console.log('Parsed ->');
             console.log(parsedMpd);
           }).catch(error => console.error(error));

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -201,6 +201,23 @@ export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   }, {});
 };
 
+const organizeCaptionServices = (captionServices) => captionServices.reduce((svcObj, svc) => {
+  if (!svc) {
+    return svcObj;
+  }
+
+  svc.forEach(({channel, language}) => {
+    svcObj[language] = {
+      autoselect: false,
+      default: false,
+      instreamId: channel,
+      language
+    };
+  });
+
+  return svcObj;
+}, {});
+
 export const formatVideoPlaylist = ({ attributes, segments, sidx }) => {
   const playlist = {
     attributes: {
@@ -258,6 +275,7 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
   const videoPlaylists = mergeDiscontiguousPlaylists(dashPlaylists.filter(videoOnly)).map(formatVideoPlaylist);
   const audioPlaylists = mergeDiscontiguousPlaylists(dashPlaylists.filter(audioOnly));
   const vttPlaylists = dashPlaylists.filter(vttOnly);
+  const captions = dashPlaylists.map((playlist) => playlist.attributes.captionServices);
 
   const master = {
     allowCache: true,
@@ -295,6 +313,10 @@ export const toM3u8 = (dashPlaylists, locations, sidxMapping = {}) => {
 
   if (vttPlaylists.length) {
     master.mediaGroups.SUBTITLES.subs = organizeVttPlaylists(vttPlaylists, sidxMapping);
+  }
+
+  if (captions.length) {
+    master.mediaGroups['CLOSED-CAPTIONS'].cc = organizeCaptionServices(captions);
   }
 
   return master;


### PR DESCRIPTION
Parse out `Accessibility` elements to see 608 and 708 signaling as defined in ANSI_SCTE 214-1 2016. These translate to the same CC object that m3u8-parser outputs with `instreamId` matching. Using https://livesim.dashif.org/livesim/testpic_2s/cea608_and_segs.mpd and this module linked in, I can see that the labels are showing up.

TODO:
- [x] 608 parsing
- [ ] 708 parsing
- [ ] tests, lots of tests.