### PR TITLE
refactor: rename SegmentInfo property from timeline to segmentTimeline

### DIFF
--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -42,7 +42,7 @@ export const buildBaseUrls = (referenceUrls, baseUrlElements) => {
  * @typedef {Object} SegmentInformation
  * @property {Object|undefined} template
  *           Contains the attributes for the SegmentTemplate node
- * @property {Object[]|undefined} timeline
+ * @property {Object[]|undefined} segmentTimeline
  *           Contains a list of atrributes for each S node within the SegmentTimeline node
  * @property {Object|undefined} list
  *           Contains the attributes for the SegmentList node
@@ -90,7 +90,7 @@ export const getSegmentInformation = (adaptationSet) => {
 
   const segmentInfo = {
     template,
-    timeline: segmentTimeline &&
+    segmentTimeline: segmentTimeline &&
       findChildren(segmentTimeline, 'S').map(s => parseAttributes(s)),
     list: segmentList && merge(
       parseAttributes(segmentList),

--- a/src/toPlaylists.js
+++ b/src/toPlaylists.js
@@ -32,7 +32,7 @@ export const generateSegments = ({ attributes, segmentInfo }) => {
     return segmentsInfo;
   }
 
-  const segments = segmentsFn(segmentAttributes, segmentInfo.timeline);
+  const segments = segmentsFn(segmentAttributes, segmentInfo.segmentTimeline);
 
   // The @duration attribute will be used to determin the playlist's targetDuration which
   // must be in seconds. Since we've generated the segment list, we no longer need

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -239,7 +239,7 @@ QUnit.test('gets SegmentTemplate and SegmentTimeline attributes', function(asser
   };
   const expected = {
     template: { media: 'video.mp4' },
-    timeline: [{ d: 10 }, { d: 5 }, { d: 7 }]
+    segmentTimeline: [{ d: 10 }, { d: 5 }, { d: 7 }]
   };
 
   assert.deepEqual(


### PR DESCRIPTION
This change helps avoid confusion between VHS-JSON timeline property and the DASH
SegmentTimeline attribute.