### PR TITLE
If label is set used this in the subtitle menu display or default to language.

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -37,7 +37,7 @@ const mergeDiscontiguousPlaylists = playlists => {
 
   return mergedPlaylists.map(playlist => {
     playlist.discontinuityStarts =
-        findIndexes(playlist.segments, 'discontinuity');
+      findIndexes(playlist.segments, 'discontinuity');
 
     return playlist;
   });
@@ -184,11 +184,11 @@ export const organizeAudioPlaylists = (playlists, sidxMapping = {}, isAudioOnly 
 
 export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
-    const label = playlist.attributes.lang || 'text';
+    const label = playlist.attributes.label || playlist.attributes.lang;
 
     if (!a[label]) {
       a[label] = {
-        language: label,
+        language: playlist.attributes.lang,
         default: false,
         autoselect: false,
         playlists: [],


### PR DESCRIPTION
Currently when setting subtitles in DASH it uses the lang attribute by default.

It should use the label attribute if it is set in the manifest.

Example of issue here.
https://jsbin.com/rinemex/edit?html,output

Relating to this issue.
https://github.com/videojs/video.js/issues/7525