### PR TITLE
[#156] fix: DASH content protection schemeIdUri as lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### TODO add version
+
+### Bug Fixes
+
+* DASH content protection schemeIdUri on input is converted to lowercase for case-insensitivity ([#156](https://github.com/videojs/mpd-parser/issues/156)
+
+
 <a name="0.21.0"></a>
 # [0.21.0](https://github.com/videojs/mpd-parser/compare/v0.20.0...v0.21.0) (2021-12-17)
 

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -175,6 +175,11 @@ export const inheritBaseUrls =
 const generateKeySystemInformation = (contentProtectionNodes) => {
   return contentProtectionNodes.reduce((acc, node) => {
     const attributes = parseAttributes(node);
+
+    // case-insensitive schemeIdUris
+    if (attributes.schemeIdUri) {
+      attributes.schemeIdUri = attributes.schemeIdUri.toLowerCase();
+    }
     const keySystem = keySystemsMap[attributes.schemeIdUri];
 
     if (keySystem) {
@@ -184,9 +189,8 @@ const generateKeySystemInformation = (contentProtectionNodes) => {
 
       if (psshNode) {
         const pssh = getContent(psshNode);
-        const psshBuffer = pssh && decodeB64ToUint8Array(pssh);
 
-        acc[keySystem].pssh = psshBuffer;
+        acc[keySystem].pssh = pssh && decodeB64ToUint8Array(pssh);
       }
     }
 

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -9,6 +9,7 @@ import { stringToMpdXml } from '../src/stringToMpdXml';
 import errors from '../src/errors';
 import QUnit from 'qunit';
 import { toPlaylists } from '../src/toPlaylists';
+import decodeB64ToUint8Array from '@videojs/vhs-utils/cjs/decode-b64-to-uint8-array';
 
 QUnit.module('buildBaseUrls');
 
@@ -2063,5 +2064,177 @@ QUnit.test('Test to check use of either Segment Template or Segment List when bo
   }];
 
   assert.equal(actual.length, 1);
+  assert.deepEqual(actual, expected);
+});
+
+QUnit.test('keySystem info for representation - lowercase UUIDs', function(assert) {
+  const NOW = Date.now();
+
+  const widevinePsshB64 = 'AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQCHJ4bvnnRl+jok5bDvj6RQ==';
+  const playreadyPsshB64 = 'AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBiAG4AaAB5AEMATwBmADUAWAAwAGEAagBvAGsANQBiAEQAdgBqADYAUgBRAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==';
+
+  const widevinePsshBytes = decodeB64ToUint8Array(widevinePsshB64);
+  const playreadyPsshBytes = decodeB64ToUint8Array(playreadyPsshB64);
+
+  // Content protection info from dash.js demo
+  const actual = inheritAttributes(stringToMpdXml(`
+    <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
+      <BaseURL>https://www.example.com/base/</BaseURL>
+      <Period>
+        <AdaptationSet mimeType="video/mp4" >
+          <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="0872786e-f9e7-465f-a3a2-4e5b0ef8fa45" />
+			    <ContentProtection value="MSPR 2.0" schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">
+				    <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBiAG4AaAB5AEMATwBmADUAWAAwAGEAagBvAGsANQBiAEQAdgBqADYAUgBRAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+				    <pro xmlns="urn:microsoft:playready">xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AYgBuAGgAeQBDAE8AZgA1AFgAMABhAGoAbwBrADUAYgBEAHYAagA2AFIAUQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</pro>
+			    </ContentProtection>
+			    <ContentProtection value="Widevine" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+				    <cenc:pssh>AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQCHJ4bvnnRl+jok5bDvj6RQ==</cenc:pssh>
+			    </ContentProtection>
+          <Role value="main"></Role>
+          <SegmentTemplate></SegmentTemplate>
+          <Representation
+            bandwidth="5000000"
+            codecs="avc1.64001e"
+            height="404"
+            id="test"
+            width="720">
+          </Representation>
+        </AdaptationSet>
+      </Period>
+    </MPD>
+  `), { NOW });
+
+  // inconsistent quoting because of quote-props
+  const expected = {
+    locations: undefined,
+    representationInfo: [{
+      attributes: {
+        'bandwidth': 5000000,
+        'baseUrl': 'https://www.example.com/base/',
+        'codecs': 'avc1.64001e',
+        'contentProtection': {
+          'com.microsoft.playready': {
+            attributes: {
+              schemeIdUri: 'urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
+              value: 'MSPR 2.0'
+            },
+            pssh: playreadyPsshBytes
+          },
+          'com.widevine.alpha': {
+            attributes: {
+              schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
+              value: 'Widevine'
+            },
+            pssh: widevinePsshBytes
+          }
+        },
+        'height': 404,
+        'id': 'test',
+        'mediaPresentationDuration': 30,
+        'mimeType': 'video/mp4',
+        'periodStart': 0,
+        'role': {
+          value: 'main'
+        },
+        'sourceDuration': 30,
+        'type': 'static',
+        'width': 720,
+        NOW,
+        'clientOffset': 0,
+        'xmlns:cenc': 'urn:mpeg:cenc:2013'
+      },
+      segmentInfo: {
+        template: {}
+      }
+    }]
+  };
+
+  assert.equal(actual.representationInfo.length, 1);
+  assert.deepEqual(actual, expected);
+});
+
+QUnit.test('keySystem info for representation - uppercase UUIDs', function(assert) {
+  const NOW = Date.now();
+
+  const widevinePsshB64 = 'AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQCHJ4bvnnRl+jok5bDvj6RQ==';
+  const playreadyPsshB64 = 'AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBiAG4AaAB5AEMATwBmADUAWAAwAGEAagBvAGsANQBiAEQAdgBqADYAUgBRAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==';
+
+  const widevinePsshBytes = decodeB64ToUint8Array(widevinePsshB64);
+  const playreadyPsshBytes = decodeB64ToUint8Array(playreadyPsshB64);
+
+  // Content protection info from dash.js demo
+  const actual = inheritAttributes(stringToMpdXml(`
+    <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
+      <BaseURL>https://www.example.com/base/</BaseURL>
+      <Period>
+        <AdaptationSet mimeType="video/mp4" >
+          <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="0872786E-F9E7-465F-A3A2-4E5B0EF8FA45" />
+			    <ContentProtection value="MSPR 2.0" schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95">
+				    <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBiAG4AaAB5AEMATwBmADUAWAAwAGEAagBvAGsANQBiAEQAdgBqADYAUgBRAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+				    <pro xmlns="urn:microsoft:playready">xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AYgBuAGgAeQBDAE8AZgA1AFgAMABhAGoAbwBrADUAYgBEAHYAagA2AFIAUQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</pro>
+			    </ContentProtection>
+			    <ContentProtection value="Widevine" schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+				    <cenc:pssh>AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQCHJ4bvnnRl+jok5bDvj6RQ==</cenc:pssh>
+			    </ContentProtection>
+          <Role value="main"></Role>
+          <SegmentTemplate></SegmentTemplate>
+          <Representation
+            bandwidth="5000000"
+            codecs="avc1.64001e"
+            height="404"
+            id="test"
+            width="720">
+          </Representation>
+        </AdaptationSet>
+      </Period>
+    </MPD>
+  `), { NOW });
+
+  // inconsistent quoting because of quote-props
+  const expected = {
+    locations: undefined,
+    representationInfo: [{
+      attributes: {
+        'bandwidth': 5000000,
+        'baseUrl': 'https://www.example.com/base/',
+        'codecs': 'avc1.64001e',
+        'contentProtection': {
+          'com.microsoft.playready': {
+            attributes: {
+              schemeIdUri: 'urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
+              value: 'MSPR 2.0'
+            },
+            pssh: playreadyPsshBytes
+          },
+          'com.widevine.alpha': {
+            attributes: {
+              schemeIdUri: 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
+              value: 'Widevine'
+            },
+            pssh: widevinePsshBytes
+          }
+        },
+        'height': 404,
+        'id': 'test',
+        'mediaPresentationDuration': 30,
+        'mimeType': 'video/mp4',
+        'periodStart': 0,
+        'role': {
+          value: 'main'
+        },
+        'sourceDuration': 30,
+        'type': 'static',
+        'width': 720,
+        NOW,
+        'clientOffset': 0,
+        'xmlns:cenc': 'urn:mpeg:cenc:2013'
+      },
+      segmentInfo: {
+        template: {}
+      }
+    }]
+  };
+
+  assert.equal(actual.representationInfo.length, 1);
   assert.deepEqual(actual, expected);
 });


### PR DESCRIPTION
[Original issue](https://github.com/videojs/mpd-parser/issues/156)

DASH ContentProtection schemeIdUri attributes are converted to lowercase on input to avoid keySystems mismatch since UUIDs should be handled case-insensitively.