### PR TITLE
fix(toM3u8): set label for vttPlaylist from label instead of lang

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -217,7 +217,7 @@ export const organizeAudioPlaylists = (playlists, sidxMapping = {}, isAudioOnly 
 
 export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
-    const label = playlist.attributes.lang || 'text';
+    const label = playlist.attributes.label || playlist.attributes.lang || 'text';
 
     if (!a[label]) {
       a[label] = {

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -911,10 +911,27 @@ QUnit.test('playlists with label', function(assert) {
       type: 'static'
     },
     segments: []
+  }, {
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      periodStart: 0,
+      mimeType: 'text/vtt',
+      type: 'static',
+      label
+    },
+    segments: []
   }];
   const output = toM3u8({ dashPlaylists });
 
   assert.ok(label in output.mediaGroups.AUDIO.audio, 'label exists');
+  assert.ok(label in output.mediaGroups.SUBTITLES.subs, 'label exists');
+
 });
 
 QUnit.test('608 captions', function(assert) {


### PR DESCRIPTION
Fix the issue when the subtitles' `label` property was set from lang instead of label