### PR TITLE
[#168] fix: set endList to false when manifest type is dynamic

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -416,7 +416,7 @@ export const toM3u8 = ({
     allowCache: true,
     discontinuityStarts: [],
     segments: [],
-    endList: true,
+    endList: type === 'static',
     mediaGroups: {
       AUDIO: {},
       VIDEO: {},

--- a/test/manifests/multiperiod-dynamic.js
+++ b/test/manifests/multiperiod-dynamic.js
@@ -18,7 +18,7 @@ export const parsedManifest = {
     start: 27.949347162000002,
     timeline: 27.949347162000002
   }],
-  endList: true,
+  endList: false,
   mediaGroups: {
     'AUDIO': {
       audio: {

--- a/test/manifests/multiperiod-startnumber-removed-periods.js
+++ b/test/manifests/multiperiod-startnumber-removed-periods.js
@@ -2,7 +2,7 @@ export const parsedManifest = {
   allowCache: true,
   discontinuityStarts: [],
   duration: 0,
-  endList: true,
+  endList: false,
   timelineStarts: [
     { start: 100, timeline: 100},
     { start: 103, timeline: 103},

--- a/test/manifests/multiperiod-startnumber.js
+++ b/test/manifests/multiperiod-startnumber.js
@@ -8,7 +8,7 @@ export const parsedManifest = {
     { start: 111, timeline: 111}
   ],
   duration: 0,
-  endList: true,
+  endList: false,
   mediaGroups: {
     'AUDIO': {
       audio: {


### PR DESCRIPTION
endList at the root level should be set to false when manifest type is dynamic.

see https://github.com/videojs/mpd-parser/issues/168 for details.