### PR TITLE
feat: add EventStream support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ const parse = (manifestString, options = {}) => {
     dashPlaylists: playlists,
     locations: parsedManifestInfo.locations,
     sidxMapping: options.sidxMapping,
-    previousManifest: options.previousManifest
+    previousManifest: options.previousManifest,
+    eventStream: parsedManifestInfo.eventStream
   });
 };
 

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -571,6 +571,6 @@ export const inheritAttributes = (mpd, options = {}) => {
   return {
     locations: mpdAttributes.locations,
     representationInfo: flatten(periods.map(toAdaptationSets(mpdAttributes, mpdBaseUrls))),
-    eventStreamInfo: flatten(periods.map(toEventStream))
+    eventStream: flatten(periods.map(toEventStream))
   };
 };

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -293,7 +293,7 @@ export const parseCaptionServiceMetadata = (service) => {
  * https://dashif-documents.azurewebsites.net/Events/master/event.html#mpd-event-timing
  *
  * @param {PeriodInformation} period object containing necessary period information
- * @return a collection of parsed eventstream event objects with
+ * @return a collection of parsed eventstream event objects
  */
 export const toEventStream = (period) => {
   // get and flatten all EventStreams tags and parse attributes and children

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -296,8 +296,8 @@ export const parseCaptionServiceMetadata = (service) => {
  * @return a collection of parsed eventstream event objects with
  */
 export const toEventStream = (period) => {
-  // get all EventStreams tags and parse attributes and children
-  return findChildren(period.node, 'EventStream').flatMap((eventStream) => {
+  // get and flatten all EventStreams tags and parse attributes and children
+  return flatten(findChildren(period.node, 'EventStream').map((eventStream) => {
     const eventStreamAttributes = parseAttributes(eventStream);
     const schemeIdUri = eventStreamAttributes.schemeIdUri;
     // schemeIdUri is mandatory for EventStream tags
@@ -323,7 +323,7 @@ export const toEventStream = (period) => {
         messageData: eventAttributes.messageData
       };
     });
-  });
+  }));
 };
 
 /**

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -288,6 +288,45 @@ export const parseCaptionServiceMetadata = (service) => {
 };
 
 /**
+ * A map callback that will parse all event stream data for a collection of periods
+ * DASH ISO_IEC_23009 5.10.2.2
+ * https://dashif-documents.azurewebsites.net/Events/master/event.html#mpd-event-timing
+ *
+ * @param {PeriodInformation} period object containing necessary period information
+ * @return a collection of parsed eventstream event objects with
+ */
+export const toEventStream = (period) => {
+  // get all EventStreams tags and parse attributes and children
+  return findChildren(period.node, 'EventStream').flatMap((eventStream) => {
+    const eventStreamAttributes = parseAttributes(eventStream);
+    const schemeIdUri = eventStreamAttributes.schemeIdUri;
+    // schemeIdUri is mandatory for EventStream tags
+
+    if (!schemeIdUri) {
+      return;
+    }
+
+    // find all Events per EventStream tag and map to return objects
+    return findChildren(eventStream, 'Event').map((event) => {
+      const eventAttributes = parseAttributes(event);
+      const presentationTime = eventAttributes.presentationTime || 0;
+      const timescale = eventStreamAttributes.timescale || 1;
+      const duration = eventAttributes.duration || 0;
+      const start = (presentationTime / timescale) + period.attributes.start;
+
+      return {
+        schemeIdUri,
+        value: eventStreamAttributes.value,
+        id: eventAttributes.id,
+        start,
+        end: start + (duration / timescale),
+        messageData: eventAttributes.messageData
+      };
+    });
+  });
+};
+
+/**
  * Maps an AdaptationSet node to a list of Representation information objects
  *
  * @name toRepresentationsCallback
@@ -531,6 +570,7 @@ export const inheritAttributes = (mpd, options = {}) => {
 
   return {
     locations: mpdAttributes.locations,
-    representationInfo: flatten(periods.map(toAdaptationSets(mpdAttributes, mpdBaseUrls)))
+    representationInfo: flatten(periods.map(toAdaptationSets(mpdAttributes, mpdBaseUrls))),
+    eventStreamInfo: flatten(periods.map(toEventStream))
   };
 };

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -300,11 +300,6 @@ export const toEventStream = (period) => {
   return flatten(findChildren(period.node, 'EventStream').map((eventStream) => {
     const eventStreamAttributes = parseAttributes(eventStream);
     const schemeIdUri = eventStreamAttributes.schemeIdUri;
-    // schemeIdUri is mandatory for EventStream tags
-
-    if (!schemeIdUri) {
-      return;
-    }
 
     // find all Events per EventStream tag and map to return objects
     return findChildren(eventStream, 'Event').map((event) => {
@@ -320,7 +315,9 @@ export const toEventStream = (period) => {
         id: eventAttributes.id,
         start,
         end: start + (duration / timescale),
-        messageData: eventAttributes.messageData
+        messageData: eventAttributes.messageData,
+        contentEncoding: eventStreamAttributes.contentEncoding,
+        presentationTimeOffset: eventStreamAttributes.presentationTimeOffset || 0
       };
     });
   }));

--- a/src/parseAttributes.js
+++ b/src/parseAttributes.js
@@ -242,6 +242,19 @@ export const parsers = {
   },
 
   /**
+   * Specifies the presentationTime.
+   *
+   * @param {string} value
+   *        value of the attribute as a string
+   *
+   * @return {number}
+   *         The parsed presentationTime
+   */
+  presentationTime(value) {
+    return parseInt(value, 10);
+  },
+
+  /**
    * Default parser for all other attributes. Acts as a no-op and just returns the value
    * as a string
    *

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -393,7 +393,8 @@ export const toM3u8 = ({
   dashPlaylists,
   locations,
   sidxMapping = {},
-  previousManifest
+  previousManifest,
+  eventStream
 }) => {
   if (!dashPlaylists.length) {
     return {};
@@ -438,6 +439,10 @@ export const toM3u8 = ({
 
   if (type === 'dynamic') {
     manifest.suggestedPresentationDelay = suggestedPresentationDelay;
+  }
+
+  if (eventStream && eventStream.length > 0) {
+    manifest.eventStream = eventStream;
   }
 
   const isAudioOnly = manifest.playlists.length === 0;

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -2323,7 +2323,7 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
       <Period id="dai_pod-0001065804-ad-1" start="PT0H0M14.9S" duration="PT9.977S">
         <BaseURL>https://www.example.com/base/</BaseURL>
         <SegmentTemplate media="$RepresentationID$/$Number$.mp4" initialization="$RepresentationID$/init.mp4"/>
-        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000">
+        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000" value="foo">
           <Event presentationTime="100" duration="0" id="0" messageData="foo"/>
           <Event presentationTime="1100" duration="0" id="5" messageData="bar"/>
           <Event presentationTime="2100" duration="0" id="6" messageData="foo_bar"/>
@@ -2338,7 +2338,7 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'foo',
         schemeIdUri: 'urn:google:dai:2018',
         start: 15,
-        value: undefined
+        value: 'foo'
       },
       {
         end: 16,
@@ -2346,7 +2346,7 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'bar',
         schemeIdUri: 'urn:google:dai:2018',
         start: 16,
-        value: undefined
+        value: 'foo'
       },
       {
         end: 17,
@@ -2354,7 +2354,7 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'foo_bar',
         schemeIdUri: 'urn:google:dai:2018',
         start: 17,
-        value: undefined
+        value: 'foo'
       }
     ],
     locations: undefined,

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -2257,7 +2257,7 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
       <Period id="dai_pod-0001065804-ad-1" start="PT17738H17M14.156S" duration="PT9.977S">
         <BaseURL>https://www.example.com/base/</BaseURL>
         <SegmentTemplate media="$RepresentationID$/$Number$.mp4" initialization="$RepresentationID$/init.mp4"/>
-        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000">
+        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000" contentEncoding="foo" presentationTimeOffset="1">
           <Event presentationTime="100" duration="0" id="0" messageData="foo"/>
           <Event presentationTime="900" duration="0" id="5" messageData="bar"/>
           <Event presentationTime="1900" duration="0" id="6" messageData="foo_bar"/>
@@ -2271,7 +2271,10 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
       messageData: 'foo',
       schemeIdUri: 'urn:google:dai:2018',
       start: 2.1,
-      value: undefined
+      value: undefined,
+      contentEncoding: 'foo',
+      presentationTimeOffset: 1
+
     },
     {
       end: 2.9,
@@ -2279,7 +2282,9 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
       messageData: 'bar',
       schemeIdUri: 'urn:google:dai:2018',
       start: 2.9,
-      value: undefined
+      value: undefined,
+      contentEncoding: 'foo',
+      presentationTimeOffset: 1
     },
     {
       end: 3.9,
@@ -2287,7 +2292,9 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
       messageData: 'foo_bar',
       schemeIdUri: 'urn:google:dai:2018',
       start: 3.9,
-      value: undefined
+      value: undefined,
+      contentEncoding: 'foo',
+      presentationTimeOffset: 1
     }
   ];
 
@@ -2297,7 +2304,7 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
   assert.deepEqual(eventStreams, expected, 'toEventStream returns the expected object');
 });
 
-QUnit.test('cannot get EventStream data from toEventStream with no schemeIdUri', function(assert) {
+QUnit.test('can get EventStream data from toEventStream with no schemeIdUri', function(assert) {
   const mpd = stringToMpdXml(`
     <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
       <Period id="dai_pod-0001065804-ad-1" start="PT17738H17M14.156S" duration="PT9.977S">
@@ -2311,10 +2318,44 @@ QUnit.test('cannot get EventStream data from toEventStream with no schemeIdUri',
       </Period>
     </MPD>`);
 
+  const expected = [
+    {
+      end: 2.1,
+      id: '0',
+      messageData: 'foo',
+      schemeIdUri: undefined,
+      start: 2.1,
+      value: undefined,
+      contentEncoding: undefined,
+      presentationTimeOffset: 0
+
+    },
+    {
+      end: 2.9,
+      id: '5',
+      messageData: 'bar',
+      schemeIdUri: undefined,
+      start: 2.9,
+      value: undefined,
+      contentEncoding: undefined,
+      presentationTimeOffset: 0
+    },
+    {
+      end: 3.9,
+      id: '6',
+      messageData: 'foo_bar',
+      schemeIdUri: undefined,
+      start: 3.9,
+      value: undefined,
+      contentEncoding: undefined,
+      presentationTimeOffset: 0
+    }
+  ];
+
   const firstPeriod = { node: findChildren(mpd, 'Period')[0], attributes: { start: 2} };
   const eventStreams = toEventStream(firstPeriod);
 
-  assert.deepEqual(eventStreams, [undefined], 'toEventStream returns the expected object');
+  assert.deepEqual(eventStreams, expected, 'toEventStream returns the expected object');
 });
 
 QUnit.test('gets eventStream from inheritAttributes', function(assert) {
@@ -2338,7 +2379,9 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'foo',
         schemeIdUri: 'urn:google:dai:2018',
         start: 15,
-        value: 'foo'
+        value: 'foo',
+        contentEncoding: undefined,
+        presentationTimeOffset: 0
       },
       {
         end: 16,
@@ -2346,7 +2389,9 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'bar',
         schemeIdUri: 'urn:google:dai:2018',
         start: 16,
-        value: 'foo'
+        value: 'foo',
+        contentEncoding: undefined,
+        presentationTimeOffset: 0
       },
       {
         end: 17,
@@ -2354,7 +2399,9 @@ QUnit.test('gets eventStream from inheritAttributes', function(assert) {
         messageData: 'foo_bar',
         schemeIdUri: 'urn:google:dai:2018',
         start: 17,
-        value: 'foo'
+        value: 'foo',
+        contentEncoding: undefined,
+        presentationTimeOffset: 0
       }
     ],
     locations: undefined,

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -3,13 +3,15 @@ import {
   buildBaseUrls,
   parseCaptionServiceMetadata,
   getSegmentInformation,
-  getPeriodStart
+  getPeriodStart,
+  toEventStream
 } from '../src/inheritAttributes';
 import { stringToMpdXml } from '../src/stringToMpdXml';
 import errors from '../src/errors';
 import QUnit from 'qunit';
 import { toPlaylists } from '../src/toPlaylists';
 import decodeB64ToUint8Array from '@videojs/vhs-utils/es/decode-b64-to-uint8-array';
+import { findChildren } from '../src/utils/xml';
 
 QUnit.module('buildBaseUrls');
 
@@ -544,6 +546,7 @@ QUnit.test('end to end - basic', function(assert) {
   `), { NOW });
 
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -618,6 +621,7 @@ QUnit.test('end to end - basic dynamic', function(assert) {
   `), { NOW });
 
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -699,6 +703,7 @@ QUnit.test('end to end - basic multiperiod', function(assert) {
   `), { NOW });
 
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -785,6 +790,7 @@ QUnit.test('end to end - inherits BaseURL from all levels', function(assert) {
   `), { NOW });
 
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -861,6 +867,7 @@ QUnit.test('end to end - alternate BaseURLs', function(assert) {
   `), { NOW });
 
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -1028,6 +1035,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
+      eventStreamInfo: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -1140,6 +1148,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
+      eventStreamInfo: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -1263,6 +1272,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
+      eventStreamInfo: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -2106,6 +2116,7 @@ QUnit.test('keySystem info for representation - lowercase UUIDs', function(asser
 
   // inconsistent quoting because of quote-props
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -2192,6 +2203,7 @@ QUnit.test('keySystem info for representation - uppercase UUIDs', function(asser
 
   // inconsistent quoting because of quote-props
   const expected = {
+    eventStreamInfo: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -2237,4 +2249,119 @@ QUnit.test('keySystem info for representation - uppercase UUIDs', function(asser
 
   assert.equal(actual.representationInfo.length, 1);
   assert.deepEqual(actual, expected);
+});
+
+QUnit.test('gets EventStream data from toEventStream', function(assert) {
+  const mpd = stringToMpdXml(`
+    <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
+      <Period id="dai_pod-0001065804-ad-1" start="PT17738H17M14.156S" duration="PT9.977S">
+        <BaseURL>https://www.example.com/base/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$/$Number$.mp4" initialization="$RepresentationID$/init.mp4"/>
+        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000">
+          <Event presentationTime="100" duration="0" id="0" messageData="foo"/>
+          <Event presentationTime="900" duration="0" id="5" messageData="bar"/>
+          <Event presentationTime="1900" duration="0" id="6" messageData="foo_bar"/>
+        </EventStream>
+      </Period>
+    </MPD>`);
+  const expected = [
+    {
+      end: 2.1,
+      id: '0',
+      messageData: 'foo',
+      schemeIdUri: 'urn:google:dai:2018',
+      start: 2.1,
+      value: undefined
+    },
+    {
+      end: 2.9,
+      id: '5',
+      messageData: 'bar',
+      schemeIdUri: 'urn:google:dai:2018',
+      start: 2.9,
+      value: undefined
+    },
+    {
+      end: 3.9,
+      id: '6',
+      messageData: 'foo_bar',
+      schemeIdUri: 'urn:google:dai:2018',
+      start: 3.9,
+      value: undefined
+    }
+  ];
+
+  const firstPeriod = { node: findChildren(mpd, 'Period')[0], attributes: { start: 2 } };
+  const eventStreams = toEventStream(firstPeriod);
+
+  assert.deepEqual(eventStreams, expected, 'getEventStreams returns the expected object');
+});
+
+QUnit.test('cannot get EventStream data from toEventStream with no schemeIdUri', function(assert) {
+  const mpd = stringToMpdXml(`
+    <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
+      <Period id="dai_pod-0001065804-ad-1" start="PT17738H17M14.156S" duration="PT9.977S">
+        <BaseURL>https://www.example.com/base/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$/$Number$.mp4" initialization="$RepresentationID$/init.mp4"/>
+        <EventStream timescale="1000">
+          <Event presentationTime="100" duration="0" id="0" messageData="foo"/>
+          <Event presentationTime="900" duration="0" id="5" messageData="bar"/>
+          <Event presentationTime="1900" duration="0" id="6" messageData="foo_bar"/>
+        </EventStream>
+      </Period>
+    </MPD>`);
+
+  const firstPeriod = { node: findChildren(mpd, 'Period')[0], attributes: { start: 2} };
+  const eventStreams = toEventStream(firstPeriod);
+
+  assert.deepEqual(eventStreams, [undefined], 'getEventStreams returns the expected object');
+});
+
+QUnit.test('gets EventStreamInfo from inheritAttributes', function(assert) {
+  const mpd = stringToMpdXml(`
+    <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
+      <Period id="dai_pod-0001065804-ad-1" start="PT0H0M14.9S" duration="PT9.977S">
+        <BaseURL>https://www.example.com/base/</BaseURL>
+        <SegmentTemplate media="$RepresentationID$/$Number$.mp4" initialization="$RepresentationID$/init.mp4"/>
+        <EventStream schemeIdUri="urn:google:dai:2018" timescale="1000">
+          <Event presentationTime="100" duration="0" id="0" messageData="foo"/>
+          <Event presentationTime="1100" duration="0" id="5" messageData="bar"/>
+          <Event presentationTime="2100" duration="0" id="6" messageData="foo_bar"/>
+        </EventStream>
+      </Period>
+    </MPD>`);
+  const expected = {
+    eventStreamInfo: [
+      {
+        end: 15,
+        id: '0',
+        messageData: 'foo',
+        schemeIdUri: 'urn:google:dai:2018',
+        start: 15,
+        value: undefined
+      },
+      {
+        end: 16,
+        id: '5',
+        messageData: 'bar',
+        schemeIdUri: 'urn:google:dai:2018',
+        start: 16,
+        value: undefined
+      },
+      {
+        end: 17,
+        id: '6',
+        messageData: 'foo_bar',
+        schemeIdUri: 'urn:google:dai:2018',
+        start: 17,
+        value: undefined
+      }
+    ],
+    locations: undefined,
+    representationInfo: []
+  };
+
+  const eventStreams = inheritAttributes(mpd);
+
+  assert.deepEqual(eventStreams, expected, 'getEventStreams returns the expected object');
 });

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -546,7 +546,7 @@ QUnit.test('end to end - basic', function(assert) {
   `), { NOW });
 
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -621,7 +621,7 @@ QUnit.test('end to end - basic dynamic', function(assert) {
   `), { NOW });
 
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -703,7 +703,7 @@ QUnit.test('end to end - basic multiperiod', function(assert) {
   `), { NOW });
 
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -790,7 +790,7 @@ QUnit.test('end to end - inherits BaseURL from all levels', function(assert) {
   `), { NOW });
 
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -867,7 +867,7 @@ QUnit.test('end to end - alternate BaseURLs', function(assert) {
   `), { NOW });
 
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -1035,7 +1035,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
-      eventStreamInfo: [],
+      eventStream: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -1148,7 +1148,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
-      eventStreamInfo: [],
+      eventStream: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -1272,7 +1272,7 @@ QUnit.test(
   `), { NOW });
 
     const expected = {
-      eventStreamInfo: [],
+      eventStream: [],
       locations: undefined,
       representationInfo: [{
         attributes: {
@@ -2116,7 +2116,7 @@ QUnit.test('keySystem info for representation - lowercase UUIDs', function(asser
 
   // inconsistent quoting because of quote-props
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -2203,7 +2203,7 @@ QUnit.test('keySystem info for representation - uppercase UUIDs', function(asser
 
   // inconsistent quoting because of quote-props
   const expected = {
-    eventStreamInfo: [],
+    eventStream: [],
     locations: undefined,
     representationInfo: [{
       attributes: {
@@ -2294,7 +2294,7 @@ QUnit.test('gets EventStream data from toEventStream', function(assert) {
   const firstPeriod = { node: findChildren(mpd, 'Period')[0], attributes: { start: 2 } };
   const eventStreams = toEventStream(firstPeriod);
 
-  assert.deepEqual(eventStreams, expected, 'getEventStreams returns the expected object');
+  assert.deepEqual(eventStreams, expected, 'toEventStream returns the expected object');
 });
 
 QUnit.test('cannot get EventStream data from toEventStream with no schemeIdUri', function(assert) {
@@ -2314,10 +2314,10 @@ QUnit.test('cannot get EventStream data from toEventStream with no schemeIdUri',
   const firstPeriod = { node: findChildren(mpd, 'Period')[0], attributes: { start: 2} };
   const eventStreams = toEventStream(firstPeriod);
 
-  assert.deepEqual(eventStreams, [undefined], 'getEventStreams returns the expected object');
+  assert.deepEqual(eventStreams, [undefined], 'toEventStream returns the expected object');
 });
 
-QUnit.test('gets EventStreamInfo from inheritAttributes', function(assert) {
+QUnit.test('gets eventStream from inheritAttributes', function(assert) {
   const mpd = stringToMpdXml(`
     <MPD mediaPresentationDuration="PT30S" xmlns:cenc="urn:mpeg:cenc:2013">
       <Period id="dai_pod-0001065804-ad-1" start="PT0H0M14.9S" duration="PT9.977S">
@@ -2331,7 +2331,7 @@ QUnit.test('gets EventStreamInfo from inheritAttributes', function(assert) {
       </Period>
     </MPD>`);
   const expected = {
-    eventStreamInfo: [
+    eventStream: [
       {
         end: 15,
         id: '0',
@@ -2363,5 +2363,5 @@ QUnit.test('gets EventStreamInfo from inheritAttributes', function(assert) {
 
   const eventStreams = inheritAttributes(mpd);
 
-  assert.deepEqual(eventStreams, expected, 'getEventStreams returns the expected object');
+  assert.deepEqual(eventStreams, expected, 'inheritAttributes returns the expected object');
 });

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -1131,3 +1131,263 @@ QUnit.test('includes all media group playlists', function(assert) {
     'included all media group playlists'
   );
 });
+
+QUnit.module('eventStream');
+
+QUnit.test('eventStreams with playlists', function(assert) {
+  const dashPlaylists = [{
+    attributes: {
+      id: '1',
+      codecs: 'foo;bar',
+      sourceDuration: 100,
+      duration: 0,
+      bandwidth: 20000,
+      periodStart: 0,
+      mimeType: 'audio/mp4',
+      type: 'static'
+    },
+    segments: []
+  }, {
+    attributes: {
+      id: '2',
+      codecs: 'foo;bar',
+      sourceDuration: 100,
+      duration: 0,
+      bandwidth: 10000,
+      periodStart: 0,
+      mimeType: 'audio/mp4',
+      type: 'static'
+    },
+    segments: []
+  }, {
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      width: 800,
+      height: 600,
+      codecs: 'foo;bar',
+      duration: 0,
+      bandwidth: 10000,
+      frameRate: 30,
+      periodStart: 0,
+      mimeType: 'video/mp4',
+      type: 'static'
+    },
+    segments: []
+  }, {
+    attributes: {
+      sourceDuration: 100,
+      id: '1',
+      bandwidth: 20000,
+      periodStart: 0,
+      mimeType: 'text/vtt',
+      type: 'static',
+      baseUrl: 'https://www.example.com/vtt'
+    }
+  }, {
+    attributes: {
+      sourceDuration: 100,
+      id: '2',
+      bandwidth: 10000,
+      periodStart: 0,
+      mimeType: 'text/vtt',
+      type: 'static',
+      baseUrl: 'https://www.example.com/vtt'
+    }
+  }];
+
+  const eventStream = [
+    {
+      end: 1,
+      id: 'one',
+      messageData: 'foo',
+      schemeIdUri: 'urn:foo.bar.2023',
+      start: 1,
+      value: 'bar'
+    },
+    {
+      end: 2,
+      id: 'two',
+      messageData: 'bar',
+      schemeIdUri: 'urn:foo.bar.2023',
+      start: 2,
+      value: 'foo'
+    },
+    {
+      end: 3,
+      id: 'three',
+      messageData: 'foo_bar',
+      schemeIdUri: 'urn:foo.bar.2023',
+      start: 3,
+      value: 'bar_foo'
+    }
+  ];
+
+  const expected = {
+    allowCache: true,
+    discontinuityStarts: [],
+    timelineStarts: [{ start: 0, timeline: 0 }],
+    duration: 100,
+    endList: true,
+    eventStream: [
+      {
+        end: 1,
+        id: 'one',
+        messageData: 'foo',
+        schemeIdUri: 'urn:foo.bar.2023',
+        start: 1,
+        value: 'bar'
+      },
+      {
+        end: 2,
+        id: 'two',
+        messageData: 'bar',
+        schemeIdUri: 'urn:foo.bar.2023',
+        start: 2,
+        value: 'foo'
+      },
+      {
+        end: 3,
+        id: 'three',
+        messageData: 'foo_bar',
+        schemeIdUri: 'urn:foo.bar.2023',
+        start: 3,
+        value: 'bar_foo'
+      }
+    ],
+    mediaGroups: {
+      AUDIO: {
+        audio: {
+          main: {
+            autoselect: true,
+            default: true,
+            language: '',
+            playlists: [{
+              attributes: {
+                BANDWIDTH: 20000,
+                CODECS: 'foo;bar',
+                NAME: '1',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 0,
+              discontinuitySequence: 0,
+              discontinuityStarts: [],
+              timelineStarts: [{ start: 0, timeline: 0 }],
+              endList: true,
+              resolvedUri: '',
+              segments: [],
+              timeline: 0,
+              uri: '',
+              targetDuration: 0
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
+                CODECS: 'foo;bar',
+                NAME: '2',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 0,
+              discontinuitySequence: 0,
+              discontinuityStarts: [],
+              timelineStarts: [{ start: 0, timeline: 0 }],
+              endList: true,
+              resolvedUri: '',
+              segments: [],
+              timeline: 0,
+              uri: '',
+              targetDuration: 0
+
+            }],
+            uri: ''
+          }
+        }
+      },
+      ['CLOSED-CAPTIONS']: {},
+      SUBTITLES: {
+        subs: {
+          text: {
+            autoselect: false,
+            default: false,
+            language: 'text',
+            playlists: [{
+              attributes: {
+                BANDWIDTH: 20000,
+                NAME: '1',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 0,
+              discontinuitySequence: 0,
+              discontinuityStarts: [],
+              timelineStarts: [{ start: 0, timeline: 0 }],
+              targetDuration: 100,
+              endList: true,
+              resolvedUri: 'https://www.example.com/vtt',
+              segments: [{
+                duration: 100,
+                resolvedUri: 'https://www.example.com/vtt',
+                timeline: 0,
+                uri: 'https://www.example.com/vtt',
+                number: 0
+              }],
+              timeline: 0,
+              uri: ''
+            }, {
+              attributes: {
+                BANDWIDTH: 10000,
+                NAME: '2',
+                ['PROGRAM-ID']: 1
+              },
+              mediaSequence: 0,
+              discontinuitySequence: 0,
+              discontinuityStarts: [],
+              timelineStarts: [{ start: 0, timeline: 0 }],
+              targetDuration: 100,
+              endList: true,
+              resolvedUri: 'https://www.example.com/vtt',
+              segments: [{
+                duration: 100,
+                resolvedUri: 'https://www.example.com/vtt',
+                timeline: 0,
+                uri: 'https://www.example.com/vtt',
+                number: 0
+              }],
+              timeline: 0,
+              uri: ''
+            }],
+            uri: ''
+          }
+        }
+      },
+      VIDEO: {}
+    },
+    playlists: [{
+      attributes: {
+        AUDIO: 'audio',
+        SUBTITLES: 'subs',
+        BANDWIDTH: 10000,
+        CODECS: 'foo;bar',
+        NAME: '1',
+        ['FRAME-RATE']: 30,
+        ['PROGRAM-ID']: 1,
+        RESOLUTION: {
+          height: 600,
+          width: 800
+        }
+      },
+      endList: true,
+      mediaSequence: 0,
+      discontinuitySequence: 0,
+      discontinuityStarts: [],
+      timelineStarts: [{ start: 0, timeline: 0 }],
+      targetDuration: 0,
+      resolvedUri: '',
+      segments: [],
+      timeline: 0,
+      uri: ''
+    }],
+    segments: [],
+    uri: ''
+  };
+
+  assert.deepEqual(toM3u8({ dashPlaylists, eventStream }), expected);
+});


### PR DESCRIPTION
Feature Added
--
**EventStream tag support**

Timed metadata can be embedded  in the DASH manifest with `<EventStream>` tags at the `<Period>` level. Each EventStream contains `<Event>` tags that represent each node of timed metadata. This pull request adds support for parsing EventStream and child Event tags and properties and returns a flattened collection of Event-like objects with the following properties:
```
{
  end: number,
  id: string,
  messageData: string,
  schemeIdUri: string,
  start: number,
  value: string,
  contentEncoding: string,
  presentationTimeOffset: number
}
```

This implementation is based off of https://dashif-documents.azurewebsites.net/Events/master/event.html#mpd-event-timing which is from the DASH spec ISO_IEC_23009 section 5.10.2.1.