### PR TITLE
fix: get event tag content

### DIFF
--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -315,7 +315,7 @@ export const toEventStream = (period) => {
         id: eventAttributes.id,
         start,
         end: start + (duration / timescale),
-        messageData: eventAttributes.messageData,
+        messageData: getContent(event) || eventAttributes.messageData,
         contentEncoding: eventStreamAttributes.contentEncoding,
         presentationTimeOffset: eventStreamAttributes.presentationTimeOffset || 0
       };


### PR DESCRIPTION
fixes Event node parsing to account for `<Event>` node content first, then messageData. See: https://dashif-documents.azurewebsites.net/Events/master/event.html#mpd-event-timing


@messageData | O | specifies the value for the event stream element. The value space and semantics must be defined by the owners of the scheme identified in the @schemeIdUri attribute. _NOTE: the use of the message data is discouraged by content authors, it is only maintained for the purpose of backward-compatibility. Including the message in the Event element is recommended in preference to using this attribute. This attribute is expected to be deprecated in the future editions of this document._
-- | -- | --


