### PR TITLE
feat: improve serviceLocation for content steering

### DIFF
--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -30,7 +30,21 @@ export const buildBaseUrls = (references, baseUrlElements) => {
 
   return flatten(references.map(function(reference) {
     return baseUrlElements.map(function(baseUrlElement) {
-      return merge(parseAttributes(baseUrlElement), { baseUrl: resolveUrl(reference.baseUrl, getContent(baseUrlElement)) });
+      const initialBaseUrl = getContent(baseUrlElement);
+      const resolvedBaseUrl = resolveUrl(reference.baseUrl, initialBaseUrl);
+
+      const finalBaseUrl = merge(
+        parseAttributes(baseUrlElement),
+        { baseUrl: resolvedBaseUrl }
+      );
+
+      // If the URL is resolved, we want to get the serviceLocation from the reference
+      // assuming there is no serviceLocation on the initialBaseUrl
+      if (resolvedBaseUrl !== initialBaseUrl) {
+        finalBaseUrl.serviceLocation = finalBaseUrl.serviceLocation || reference.serviceLocation;
+      }
+
+      return finalBaseUrl;
     });
   }));
 };

--- a/src/segment/segmentTemplate.js
+++ b/src/segment/segmentTemplate.js
@@ -147,7 +147,8 @@ export const segmentsFromTemplate = (attributes, segmentTimeline) => {
   const mapSegment = urlTypeToSegment({
     baseUrl: attributes.baseUrl,
     source: constructTemplateUrl(initialization.sourceURL, templateValues),
-    range: initialization.range
+    range: initialization.range,
+    serviceLocation: attributes.serviceLocation
   });
 
   const segments = parseTemplateInfo(attributes, segmentTimeline);
@@ -172,6 +173,7 @@ export const segmentsFromTemplate = (attributes, segmentTimeline) => {
       timeline: segment.timeline,
       duration: segment.duration,
       resolvedUri: resolveUrl(attributes.baseUrl || '', uri),
+      serviceLocation: attributes.serviceLocation,
       map: mapSegment,
       number: segment.number,
       presentationTime

--- a/src/segment/urlType.js
+++ b/src/segment/urlType.js
@@ -23,13 +23,16 @@ import window from 'global/window';
  * @param {string} source - source url for segment
  * @param {string} range - optional range used for range calls,
  *   follows  RFC 2616, Clause 14.35.1
+ * @param {string} serviceLocation - optional serviceLocation provided by <BaseUrl> nodes
+ *   used for content steering
  * @return {SingleUri} full segment information transformed into a format similar
  *   to m3u8-parser
  */
-export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '', indexRange = '' }) => {
+export const urlTypeToSegment = ({ baseUrl = '', source = '', range = '', serviceLocation = null, indexRange = '' }) => {
   const segment = {
     uri: source,
-    resolvedUri: resolveUrl(baseUrl || '', source)
+    resolvedUri: resolveUrl(baseUrl || '', source),
+    serviceLocation
   };
 
   if (range || indexRange) {

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -137,6 +137,7 @@ export const formatVttPlaylist = ({
       timeline: attributes.periodStart,
       resolvedUri: attributes.baseUrl || '',
       duration: attributes.sourceDuration,
+      serviceLocation: attributes.serviceLocation,
       number: 0
     }];
     // targetDuration should be the same duration as the only segment
@@ -161,6 +162,7 @@ export const formatVttPlaylist = ({
     targetDuration: attributes.duration,
     timelineStarts: attributes.timelineStarts,
     discontinuityStarts,
+    serviceLocation: attributes.serviceLocation,
     discontinuitySequence,
     mediaSequence,
     segments

--- a/test/inheritAttributes.test.js
+++ b/test/inheritAttributes.test.js
@@ -927,10 +927,11 @@ QUnit.test('end to end - content steering - resolvable base URLs', function(asse
           id="test"
           width="720">
         </Representation>
+        <BaseURL>/video</BaseURL>
       </AdaptationSet>
       <AdaptationSet mimeType="text/vtt" lang="en">
         <Representation bandwidth="256" id="en">
-        <BaseURL>/video</BaseURL>
+        <BaseURL>/vtt</BaseURL>
         </Representation>
       </AdaptationSet>
     </Period>
@@ -957,7 +958,7 @@ QUnit.test('end to end - content steering - resolvable base URLs', function(asse
         attributes: {
           NOW,
           bandwidth: 5000000,
-          baseUrl: 'https://cdn1.example.com/',
+          baseUrl: 'https://cdn1.example.com/video',
           clientOffset: 0,
           codecs: 'avc1.64001e',
           height: 404,
@@ -980,7 +981,7 @@ QUnit.test('end to end - content steering - resolvable base URLs', function(asse
         attributes: {
           NOW,
           bandwidth: 5000000,
-          baseUrl: 'https://cdn2.example.com/',
+          baseUrl: 'https://cdn2.example.com/video',
           clientOffset: 0,
           codecs: 'avc1.64001e',
           height: 404,
@@ -1003,13 +1004,14 @@ QUnit.test('end to end - content steering - resolvable base URLs', function(asse
         attributes: {
           NOW,
           bandwidth: 256,
-          baseUrl: 'https://cdn1.example.com/video',
+          baseUrl: 'https://cdn1.example.com/vtt',
           clientOffset: 0,
           id: 'en',
           lang: 'en',
           mimeType: 'text/vtt',
           periodStart: 0,
           role: {},
+          serviceLocation: 'alpha',
           sourceDuration: 0,
           type: 'dyanmic'
         },
@@ -1019,13 +1021,14 @@ QUnit.test('end to end - content steering - resolvable base URLs', function(asse
         attributes: {
           NOW,
           bandwidth: 256,
-          baseUrl: 'https://cdn2.example.com/video',
+          baseUrl: 'https://cdn2.example.com/vtt',
           clientOffset: 0,
           id: 'en',
           lang: 'en',
           mimeType: 'text/vtt',
           periodStart: 0,
           role: {},
+          serviceLocation: 'beta',
           sourceDuration: 0,
           type: 'dyanmic'
         },

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -221,6 +221,286 @@ QUnit.test('playlists with content steering', function(assert) {
     serverURL: 'https://example.com/app/url'
   };
 
+  const dashPlaylists = [
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn1.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        duration: 0,
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn1.example.com/video',
+            uri: '',
+            serviceLocation: 'alpha'
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn1.example.com/video',
+          serviceLocation: 'alpha',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn2.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        duration: 0,
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn2.example.com/video',
+            serviceLocation: 'beta',
+            uri: ''
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn2.example.com/video',
+          serviceLocation: 'beta',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn1.example.com/vtt',
+        clientOffset: 0,
+        duration: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn1.example.com/vtt',
+            serviceLocation: 'alpha',
+            uri: ''
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn1.example.com/vtt',
+          serviceLocation: 'alpha',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn2.example.com/vtt',
+        clientOffset: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      }
+    }
+  ];
+
+  const expected = {
+    allowCache: true,
+    contentSteering: {
+      defaultServiceLocation: 'beta',
+      proxyServerURL: 'http://127.0.0.1:3455/steer',
+      queryBeforeStart: false,
+      serverURL: 'https://example.com/app/url'
+    },
+    discontinuityStarts: [],
+    duration: 0,
+    endList: true,
+    mediaGroups: {
+      AUDIO: {},
+      ['CLOSED-CAPTIONS']: {},
+      SUBTITLES: {
+        subs: {
+          en: {
+            autoselect: false,
+            default: false,
+            language: 'en',
+            playlists: [
+              {
+                attributes: {
+                  BANDWIDTH: 256,
+                  NAME: 'en',
+                  ['PROGRAM-ID']: 1
+                },
+                discontinuitySequence: 0,
+                discontinuityStarts: [],
+                endList: false,
+                mediaSequence: 0,
+                resolvedUri: 'https://cdn1.example.com/vtt',
+                segments: [
+                  {
+                    duration: 0,
+                    map: {
+                      resolvedUri: 'https://cdn1.example.com/vtt',
+                      serviceLocation: 'alpha',
+                      uri: ''
+                    },
+                    number: 0,
+                    presentationTime: 0,
+                    resolvedUri: 'https://cdn1.example.com/vtt',
+                    serviceLocation: 'alpha',
+                    timeline: 0,
+                    uri: ''
+                  }
+                ],
+                serviceLocation: 'alpha',
+                targetDuration: 0,
+                timeline: 0,
+                timelineStarts: [
+                  {
+                    start: 0,
+                    timeline: 0
+                  },
+                  {
+                    start: 0,
+                    timeline: 0
+                  }
+                ],
+                uri: ''
+              }
+            ],
+            uri: ''
+          }
+        }
+      },
+      VIDEO: {}
+    },
+    playlists: [
+      {
+        attributes: {
+          AUDIO: 'audio',
+          BANDWIDTH: 5000000,
+          CODECS: 'avc1.64001e',
+          NAME: 'test',
+          ['PROGRAM-ID']: 1,
+          RESOLUTION: {
+            height: 404,
+            width: 720
+          },
+          SUBTITLES: 'subs'
+        },
+        discontinuitySequence: 0,
+        discontinuityStarts: [
+          1
+        ],
+        endList: false,
+        mediaSequence: 0,
+        resolvedUri: '',
+        segments: [
+          {
+            duration: 0,
+            map: {
+              resolvedUri: 'https://cdn1.example.com/video',
+              serviceLocation: 'alpha',
+              uri: ''
+            },
+            number: 0,
+            presentationTime: 0,
+            resolvedUri: 'https://cdn1.example.com/video',
+            serviceLocation: 'alpha',
+            timeline: 0,
+            uri: ''
+          },
+          {
+            discontinuity: true,
+            duration: 0,
+            map: {
+              resolvedUri: 'https://cdn2.example.com/video',
+              serviceLocation: 'beta',
+              uri: ''
+            },
+            number: 1,
+            presentationTime: 0,
+            resolvedUri: 'https://cdn2.example.com/video',
+            serviceLocation: 'beta',
+            timeline: 0,
+            uri: ''
+          }
+        ],
+        targetDuration: 0,
+        timeline: 0,
+        timelineStarts: [
+          {
+            start: 0,
+            timeline: 0
+          },
+          {
+            start: 0,
+            timeline: 0
+          }
+        ],
+        uri: ''
+      }
+    ],
+    segments: [],
+    timelineStarts: [
+      {
+        start: 0,
+        timeline: 0
+      }
+    ],
+    uri: ''
+  };
+
+  assert.deepEqual(toM3u8({ dashPlaylists, contentSteering }), expected);
+});
+
+QUnit.test('playlists with content steering', function(assert) {
+  const contentSteering = {
+    defaultServiceLocation: 'beta',
+    proxyServerURL: 'http://127.0.0.1:3455/steer',
+    queryBeforeStart: false,
+    serverURL: 'https://example.com/app/url'
+  };
+
   const dashPlaylists = [{
     attributes: {
       bandwidth: 5000000,

--- a/test/toPlaylists.test.js
+++ b/test/toPlaylists.test.js
@@ -410,3 +410,210 @@ QUnit.test('presentationTime accounts for presentationTimeOffset', function(asse
 
   assert.deepEqual(toPlaylists(representations), playlists);
 });
+
+QUnit.test('content steering', function(assert) {
+  const representations = [
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn1.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segmentInfo: {
+        template: {}
+      }
+    },
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn2.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segmentInfo: {
+        template: {}
+      }
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn1.example.com/vtt',
+        clientOffset: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      },
+      segmentInfo: {
+        template: {}
+      }
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn2.example.com/vtt',
+        clientOffset: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      },
+      segmentInfo: {}
+    }
+  ];
+
+  const playlists = [
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn1.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        duration: 0,
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn1.example.com/video',
+            uri: '',
+            serviceLocation: 'alpha'
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn1.example.com/video',
+          serviceLocation: 'alpha',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 5000000,
+        baseUrl: 'https://cdn2.example.com/video',
+        clientOffset: 0,
+        codecs: 'avc1.64001e',
+        duration: 0,
+        height: 404,
+        id: 'test',
+        mimeType: 'video/mp4',
+        periodStart: 0,
+        role: {
+          value: 'main'
+        },
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic',
+        width: 720
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn2.example.com/video',
+            serviceLocation: 'beta',
+            uri: ''
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn2.example.com/video',
+          serviceLocation: 'beta',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn1.example.com/vtt',
+        clientOffset: 0,
+        duration: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'alpha',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      },
+      segments: [
+        {
+          duration: 0,
+          map: {
+            resolvedUri: 'https://cdn1.example.com/vtt',
+            serviceLocation: 'alpha',
+            uri: ''
+          },
+          number: 1,
+          presentationTime: 0,
+          resolvedUri: 'https://cdn1.example.com/vtt',
+          serviceLocation: 'alpha',
+          timeline: 0,
+          uri: ''
+        }
+      ]
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn2.example.com/vtt',
+        clientOffset: 0,
+        id: 'en',
+        lang: 'en',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      }
+    }
+  ];
+
+  assert.deepEqual(toPlaylists(representations), playlists);
+});


### PR DESCRIPTION
Update to ensure the `serviceLocation` field from the BaseURLs from DASH manifests are passed to VHS correctly.