### PR TITLE
chore: update vhs-utils dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,9 +1673,9 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
+      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/vhs-utils": "^3.0.5",
+    "@videojs/vhs-utils": "^4.0.0",
     "@xmldom/xmldom": "^0.8.3",
     "global": "^4.4.0"
   },


### PR DESCRIPTION
## Description

update @videojs/vhs-utils to version 4.0.0

refers https://github.com/videojs/video.js/issues/8491