### PR TITLE
fix: ensure vtt tracks language is set correctly

### DIFF
--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -246,7 +246,7 @@ export const organizeAudioPlaylists = (playlists, sidxMapping = {}, isAudioOnly 
 export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
     const label = playlist.attributes.label || playlist.attributes.lang || 'text';
-    const language = playlist.attributes.lang || playlist.attributes.label || 'en';
+    const language = playlist.attributes.lang || 'und';
 
     if (!a[label]) {
       a[label] = {

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -246,10 +246,11 @@ export const organizeAudioPlaylists = (playlists, sidxMapping = {}, isAudioOnly 
 export const organizeVttPlaylists = (playlists, sidxMapping = {}) => {
   return playlists.reduce((a, playlist) => {
     const label = playlist.attributes.label || playlist.attributes.lang || 'text';
+    const language = playlist.attributes.lang || playlist.attributes.label || 'en';
 
     if (!a[label]) {
       a[label] = {
-        language: label,
+        language,
         default: false,
         autoselect: false,
         playlists: [],

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -129,7 +129,7 @@ QUnit.test('playlists', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'en',
+            language: 'und',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,
@@ -1115,7 +1115,7 @@ QUnit.test('playlists with segments', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'en',
+            language: 'und',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,
@@ -1948,7 +1948,7 @@ QUnit.test('eventStreams with playlists', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'en',
+            language: 'und',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,

--- a/test/toM3u8.test.js
+++ b/test/toM3u8.test.js
@@ -129,7 +129,7 @@ QUnit.test('playlists', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'text',
+            language: 'en',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,
@@ -334,6 +334,22 @@ QUnit.test('playlists with content steering and resolvable URLs', function(asser
         sourceDuration: 0,
         type: 'dyanmic'
       }
+    },
+    {
+      attributes: {
+        bandwidth: 256,
+        baseUrl: 'https://cdn3.example.com/vtt',
+        clientOffset: 0,
+        id: 'fr',
+        label: 'french',
+        lang: 'fr',
+        mimeType: 'text/vtt',
+        periodStart: 0,
+        role: {},
+        serviceLocation: 'beta',
+        sourceDuration: 0,
+        type: 'dyanmic'
+      }
     }
   ];
 
@@ -353,6 +369,45 @@ QUnit.test('playlists with content steering and resolvable URLs', function(asser
       ['CLOSED-CAPTIONS']: {},
       SUBTITLES: {
         subs: {
+          french: {
+            autoselect: false,
+            default: false,
+            language: 'fr',
+            playlists: [
+              {
+                attributes: {
+                  BANDWIDTH: 256,
+                  NAME: 'fr',
+                  ['PROGRAM-ID']: 1,
+                  serviceLocation: 'beta'
+                },
+                discontinuitySequence: 0,
+                discontinuityStarts: [],
+                endList: false,
+                mediaSequence: 0,
+                resolvedUri: 'https://cdn3.example.com/vtt',
+                segments: [
+                  {
+                    duration: 0,
+                    number: 0,
+                    resolvedUri: 'https://cdn3.example.com/vtt',
+                    timeline: 0,
+                    uri: 'https://cdn3.example.com/vtt'
+                  }
+                ],
+                targetDuration: 0,
+                timeline: 0,
+                timelineStarts: [
+                  {
+                    start: 0,
+                    timeline: 0
+                  }
+                ],
+                uri: ''
+              }
+            ],
+            uri: ''
+          },
           en: {
             autoselect: false,
             default: false,
@@ -1060,7 +1115,7 @@ QUnit.test('playlists with segments', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'text',
+            language: 'en',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,
@@ -1893,7 +1948,7 @@ QUnit.test('eventStreams with playlists', function(assert) {
           text: {
             autoselect: false,
             default: false,
-            language: 'text',
+            language: 'en',
             playlists: [{
               attributes: {
                 BANDWIDTH: 20000,


### PR DESCRIPTION
## Description

In DASH, the language property we set on VTT tracks should be accurate. As of now, this value is the label when it exists, THEN the language.

This change sets the language to the `lang` property if it exists, then the label, and then `en` by default.