### PR TITLE
securing identifierPattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
-on: [push, pull_request]
-
+on: [push, pull_request, workflow_dispatch]
+  
 jobs:
   should-skip:
     continue-on-error: true

--- a/src/segment/segmentTemplate.js
+++ b/src/segment/segmentTemplate.js
@@ -3,7 +3,7 @@ import urlTypeToSegment from './urlType';
 import { parseByTimeline } from './timelineTimeParser';
 import { parseByDuration } from './durationTimeParser';
 
-const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
+const identifierPattern = /\$([A-Za-z_]*)(?:(%0)([0-9]+)d)?\$/g;
 
 /**
  * Replaces template identifiers with corresponding values. To be used as the callback


### PR DESCRIPTION
It used to also match ^, ` , [, \, and ] where it shouldn't. This triggers CodeQL vulnerability reports.